### PR TITLE
Correção que minor bug e criação do método hashCode

### DIFF
--- a/src/org/unbiquitous/uos/core/messageEngine/dataType/UpService.java
+++ b/src/org/unbiquitous/uos/core/messageEngine/dataType/UpService.java
@@ -54,12 +54,22 @@ public class UpService {
 	}
 	
 	@Override
-	public boolean equals(Object obj) {
+	public boolean equals(Object obj)
+	{
 		if (obj == null || ! (obj instanceof UpService))
 			return false;
 		
 		UpService d = (UpService) obj;
-		return this.name.equals(d.name);
+		return this.name == null ? d.name == null : this.name.equals(d.name);
+	}
+	
+	@Override
+	public int hashCode()
+	{
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
 	}
 
 	public JSONObject toJSON() throws JSONException {


### PR DESCRIPTION
O método equals não verifica a variável name por null, o que poderia causar NPE.
Além disso a classe, por não implementar o método hashCode, viola o seu contrato, que especifica que objetos iguais devem retornar o mesmo hashCode.
