### PR TITLE
Small improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings/
 target/
 *.class
+.idea/
+*.iml

--- a/src/org/unbiquitous/uos/core/ClassLoaderUtils.java
+++ b/src/org/unbiquitous/uos/core/ClassLoaderUtils.java
@@ -23,7 +23,7 @@ public class ClassLoaderUtils {
 
 		@Override
 		public ClassLoader getParentClassLoader() {
-			return ClassLoader.getSystemClassLoader();
+			return this.getClass().getClassLoader();
 		}
 	}
 

--- a/src/org/unbiquitous/uos/core/adaptabitilyEngine/EventManager.java
+++ b/src/org/unbiquitous/uos/core/adaptabitilyEngine/EventManager.java
@@ -1,13 +1,5 @@
 package org.unbiquitous.uos.core.adaptabitilyEngine;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.unbiquitous.uos.core.UOSLogging;
 import org.unbiquitous.uos.core.messageEngine.MessageEngine;
 import org.unbiquitous.uos.core.messageEngine.MessageEngineException;
@@ -17,347 +9,275 @@ import org.unbiquitous.uos.core.messageEngine.messages.Call;
 import org.unbiquitous.uos.core.messageEngine.messages.Notify;
 import org.unbiquitous.uos.core.messageEngine.messages.Response;
 
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.unbiquitous.uos.core.ClassLoaderUtils.chainHashCode;
+
 /**
  * Class responsible for managing the events received and the event listeners in the current device.
- * 
- * @author Fabricio Nogueira Buzeto
  *
+ * @author Fabricio Nogueira Buzeto
  */
 public class EventManager implements NotifyHandler {
-	
-	private static Logger logger = UOSLogging.getLogger();
-	
-	private static final String REGISTER_EVENT_LISTENER_EVENT_KEY_PARAMETER = "eventKey";
 
-	private static final String REGISTER_LISTENER_SERVICE = "registerListener";
-	private static final String UNREGISTER_LISTENER_SERVICE = "unregisterListener";
+    private static Logger logger = UOSLogging.getLogger();
 
-	private Map<String, List<ListenerInfo>> listenerMap = new HashMap<String, List<ListenerInfo>>();
-	
-	private MessageEngine messageEngine;
-	
-	public EventManager(MessageEngine messageEngine) {
-		this.messageEngine = messageEngine;
-	}
-	
-	private static class ListenerInfo{
-		UosEventListener listener;
-		UpDevice device;
-		String driver;
-		String instanceId;
-		String eventKey;
-	}
-	
-	/**
-	 * Sends a notify message to the device informed.
-	 * 
-	 * @param notify Notify message to be sent.
-	 * @param device Device which is going to receive the notofy event
-	 * @throws MessageEngineException
-	 */
-	public void notify(Notify notify, UpDevice device) throws NotifyException{
-		try {
-			if(device == null){
-				handleNofify(notify, device);
-			}else{
-				messageEngine.notify(notify, device);
-			}
-		} catch (MessageEngineException e) {
-			throw new NotifyException(e);
-		}
-	}
-	
-	/**
-	 * This method formats a unique identifier for the event.
-	 */
-	private static String getEventIdentifier(UpDevice device, String driver, String instanceId, String eventKey){
-		StringBuilder id =  new StringBuilder();
-		if (device != null 
-				&& device.getName() != null
-				&& !device.getName().isEmpty()){
-			id.append("@"+device.getName());
-		}
-		if (driver != null
-				&& !driver.isEmpty()){
-			id.append("*"+driver);
-		}
-		if (eventKey != null
-				&& !eventKey.isEmpty()){
-			id.append("."+eventKey);
-		}
-		if (instanceId != null
-				&& !instanceId.isEmpty()){
-			id.append("#"+instanceId);
-		}
-		return id.toString();
-	}
-	
-	/**
-	 * Register a Listener for a event, driver and device specified.
-	 * 
-	 * @param listener UosEventListener responsible for dealing with the event.
-	 * @param device Device which event must be listened
-	 * @param driver Driver responsible for the event.
-	 * @param instanceId Instance Identifier of the driver to be registered upon. (Optional)
-	 * @param eventKey EventKey that identifies the wanted event to be listened.
-	 * @throws NotifyException In case of an error.
-	 */
-	public void register(UosEventListener listener, UpDevice device, 
-			String driver, String instanceId, String eventKey,
-			Map<String,Object> parameters) throws NotifyException{
-		
-		// If the listener is already registered it cannot be registered again
-		String eventIdentifier = getEventIdentifier(device, driver, instanceId, eventKey);
-		logger.fine("Registering listener for event :"+eventIdentifier);
-		
-		if (findListener(listener, listenerMap.get(eventIdentifier))== null){
-			ListenerInfo info = new ListenerInfo();
-			
-			info.driver = driver;
-			info.instanceId = instanceId;
-			info.eventKey = eventKey;
-			info.listener = listener;
-			info.device = device;
-			
-			registerNewListener(device, parameters, eventIdentifier, info);
-		}
-	}
+    private static final String REGISTER_EVENT_LISTENER_EVENT_KEY_PARAMETER = "eventKey";
 
-	private void registerNewListener(UpDevice device,
-			Map<String, Object> parameters, String eventIdentifier,
-			ListenerInfo info) throws NotifyException {
-		try {
-			if (device != null){
-				sendRegister(device, parameters, info);
-			}
-			// If the registry process goes ok, then add the listenner to the listener map
-			addToListenerMap(eventIdentifier, info);				
-			logger.fine("Registered listener for event :"+eventIdentifier);
-		} catch (MessageEngineException e) {
-			throw new NotifyException(e);
-		}
-	}
+    private static final String REGISTER_LISTENER_SERVICE = "registerListener";
+    private static final String UNREGISTER_LISTENER_SERVICE = "unregisterListener";
 
-	private void sendRegister(UpDevice device, Map<String, Object> parameters,
-			ListenerInfo info) throws NotifyException {
-		// Send the event register request to the called device
-		Call serviceCall = buildRegisterCall(parameters, info);
-		Response response = messageEngine.callService(device, serviceCall);
-		handleErrors(response);
-	}
+    private ListenerDao listenerDao = new ListenerDao();
 
-	private void handleErrors(Response response) throws NotifyException {
-		if (response == null){
-			throw new NotifyException("No response received during register process.");
-		}else if(response.getError() != null && !response.getError().isEmpty()){
-			throw new NotifyException(response.getError());
-		}
-	}
+    private MessageEngine messageEngine;
 
-	private Call buildRegisterCall(Map<String, Object> parameters,
-			ListenerInfo info) throws NotifyException {
-		Call serviceCall = new Call(info.driver,REGISTER_LISTENER_SERVICE,info.instanceId);
-		serviceCall.addParameter(REGISTER_EVENT_LISTENER_EVENT_KEY_PARAMETER, info.eventKey);
-		addExtraParameters(parameters, serviceCall);
-		return serviceCall;
-	}
+    public EventManager(MessageEngine messageEngine) {
+        this.messageEngine = messageEngine;
+    }
 
-	private void addExtraParameters(Map<String, Object> parameters,
-			Call serviceCall) throws NotifyException {
-		if (parameters != null){
-			for(String key : parameters.keySet()){
-				checkIfKeyIsValid(key);
-				serviceCall.addParameter(key, parameters.get(key));
-			}
-		}
-	}
+    /**
+     * Sends a notify message to the device informed.
+     *
+     * @param notify Notify message to be sent.
+     * @param device Device which is going to receive the notofy event
+     * @throws MessageEngineException
+     */
+    public void notify(Notify notify, UpDevice device) throws NotifyException {
+        try {
+            if (device == null) {
+                handleNofify(notify, device);
+            } else {
+                messageEngine.notify(notify, device);
+            }
+        } catch (MessageEngineException e) {
+            throw new NotifyException(e);
+        }
+    }
 
-	private void checkIfKeyIsValid(String key) throws NotifyException {
-		if (key.equalsIgnoreCase(REGISTER_EVENT_LISTENER_EVENT_KEY_PARAMETER)){
-			throw new NotifyException("Can't use reserved keys as parameters for registerForEvent");
-		}
-	}
-	
-	private void addToListenerMap(String eventIdentifier, ListenerInfo info) {
-		if (listenerMap.get(eventIdentifier) == null){
-			listenerMap.put(eventIdentifier,new ArrayList<ListenerInfo>());
-		}
-		listenerMap.get(eventIdentifier).add(info);
-	}
+    /**
+     * Register a Listener for a event, driver and device specified.
+     *
+     * @param listener   UosEventListener responsible for dealing with the event.
+     * @param device     Device which event must be listened
+     * @param driver     Driver responsible for the event.
+     * @param instanceId Instance Identifier of the driver to be registered upon. (Optional)
+     * @param eventKey   EventKey that identifies the wanted event to be listened.
+     * @throws NotifyException In case of an error.
+     */
+    public void register(
+            UosEventListener listener,
+            UpDevice device,
+            String driver,
+            String instanceId,
+            String eventKey,
+            Map<String, Object> parameters) throws NotifyException {
 
-	
-	/**
-	 * Removes a listener for receiving Notify events and notifies the event driver of its removal.
-	 * 
-	 * @param listener Listener to be removed.
-	 * @param driver Driver from which the listener must be removed (If not informed all drivers will be considered).
-	 * @param instanceId InstanceId from the Driver which the listener must be removed (If not informed all instances will be considered).
-	 * @param eventKey EventKey from which the listener must be removed (If not informed all events will be considered).
-	 * @throws NotifyException
-	 */
-	public void unregister(UosEventListener listener, UpDevice device, String driver, String instanceId, String eventKey) throws NotifyException{
-		
-		List<ListenerInfo> listeners = findListeners(	device, driver,
-														instanceId, eventKey);
-		
-		if (listeners == null){
-			return;
-		}
-		
-		NotifyException exception = null;
-		
-		// Secondly filter listenners by the other data [listener, driver and instanceId]
-		Iterator<ListenerInfo> it = listeners.iterator();
-		ListenerInfo li;
-		while(it.hasNext() ){
-			li = it.next();
-			
-			// only if its the same listener, it should be removed
-			if (li.listener.equals(listener) ){
-				boolean remove = true;
-				
-				// If the driver name is informed, and it's not the same, it must not be removed
-				if (driver != null && li.driver != null){
-					remove = li.driver.equals(driver);
-				}
-				
-				// If the instanceId is informed, and it's not the same, it must not be removed
-				if (instanceId != null && li.instanceId != null){
-					remove = li.instanceId.equals(instanceId);
-				}
-				
-				if (remove){
-					try {
-						//Notify device of the listener removal
-						unregisterForEvent(li);
-						
-						//remove listener from the list
-						it.remove();
-						
-					} catch (NotifyException e) {
-						logger.log(Level.SEVERE,"Failed to unregisterForEvent",e);
-						exception = e;
-					}
-				}
-			}
-		}
-		
-		// In case of an error, throw it
-		if (exception != null){
-			throw exception;
-		}
-	}
+        if (listener == null)
+            throw new NullPointerException("listener");
+        EventFilter filter = new EventFilter(device, driver, instanceId, eventKey);
+        logger.fine("Registering listener for event : " + filter);
 
-	private List<ListenerInfo> findListeners(UpDevice device, String driver,
-			String instanceId, String eventKey) {
-		// First filter the listeners by the event key 
-		List<ListenerInfo> listeners = null;
-		
-		if (eventKey == null){
-			// In this case all eventKeys must be checked for the listener to be removed.
-			listeners = new ArrayList<ListenerInfo>();
-			for (List<ListenerInfo> list : listenerMap.values()){
-				listeners.addAll(list);
-			}
-		}else{
-			// In case a eventKey is informed, then only the listeners for that event key must be used
-			String eventIdentifier = getEventIdentifier(device, driver, instanceId, eventKey);
-			listeners = listenerMap.get(eventIdentifier);
-		}
-		return listeners;
-	}
-	
-	/**
-	 * Unregister an single listener from a DeviceDriver sending the apropriate message.
-	 * 
-	 * @param listenerInfo Information about the listener.
-	 * 
-	 * @throws NotifyException
-	 */
-	private void unregisterForEvent(ListenerInfo listenerInfo) throws NotifyException{
-		// Send the event register request to the called device
-		Call serviceCall = new Call(listenerInfo.driver,UNREGISTER_LISTENER_SERVICE,listenerInfo.instanceId);
-		
-		serviceCall.addParameter(REGISTER_EVENT_LISTENER_EVENT_KEY_PARAMETER, listenerInfo.eventKey);
-		
-		try {
-			Response response = messageEngine.callService(listenerInfo.device, serviceCall);
-			if (response == null || (response.getError() != null && !response.getError().isEmpty())){
-				throw new NotifyException(response.getError());
-			}
-			
-		} catch (MessageEngineException e) {
-			throw new NotifyException(e);
-		}
-	}
-	
-	
-	/**
-	 * @see NotifyHandler#handleNofify(Notify)
-	 */
-	public void handleNofify(Notify notify, UpDevice device) {
-		if (notify == null || notify.getEventKey() == null || notify.getEventKey().isEmpty()){
-			logger.fine("No information in notify to handle.");
-		}
-		
-		if (listenerMap == null || listenerMap.isEmpty()){
-			logger.fine("No listeners waiting for notify events.");
-		}
-		
-		//Notifying listeners from more specific to more general entries
-		
-		String eventIdentifier;
-		// First full entries (device, driver, event, intanceId)
-		eventIdentifier = getEventIdentifier(device, notify.getDriver(), notify.getInstanceId(), notify.getEventKey());
-		List<ListenerInfo> listeners = listenerMap.get(eventIdentifier);
-		handleNotify(notify, listeners, eventIdentifier);
-		
-		// After less general entries (device, driver, event)
-		eventIdentifier = getEventIdentifier(device, notify.getDriver(), null, notify.getEventKey());
-		listeners = listenerMap.get(eventIdentifier);
-		handleNotify(notify, listeners, eventIdentifier);
+        try {
+            if (device != null)
+                sendRegister(device, parameters, filter);
+            listenerDao.insert(listener, filter);
+            logger.fine("Registered listener for event :" + filter);
+        } catch (MessageEngineException e) {
+            throw new NotifyException(e);
+        }
+    }
 
-		// An then the least general entries (driver, event)
-		eventIdentifier = getEventIdentifier(null, notify.getDriver(), null, notify.getEventKey());
-		listeners = listenerMap.get(eventIdentifier);
-		handleNotify(notify, listeners, eventIdentifier);
-		
-	}
+    private void sendRegister(UpDevice device, Map<String, Object> parameters, EventFilter filter) throws NotifyException {
+        Call serviceCall = new Call(filter.driver, REGISTER_LISTENER_SERVICE, filter.id);
+        serviceCall.addParameter(REGISTER_EVENT_LISTENER_EVENT_KEY_PARAMETER, filter.key);
+        addExtraParameters(parameters, serviceCall);
 
-	private void handleNotify(Notify notify, List<ListenerInfo> listeners, String eventIdentifier) {
-		if (listeners == null || listeners.isEmpty()){
-			logger.fine("No listeners waiting for notify events for the key '"+eventIdentifier+"'.");
-			return;
-		}
-		
-		// call handlers in each listener
-		for(ListenerInfo li : listeners){
-			if (li.listener != null){
-				li.listener.handleEvent(notify);
-			}
-		}
-	}
-	
-	/**
-	 * Find a listener instance in a list of ListenerInfos
-	 * 
-	 * @param listener Listener to be found.
-	 * @param list List to search in.
-	 * @return LinstenerInfo for the listener, if found.
-	 */
-	private ListenerInfo findListener(UosEventListener listener, List<ListenerInfo> list){
-		ListenerInfo info = null;
-		
-		if (list != null && !list.isEmpty() && listener != null){
-			for (ListenerInfo li : list){
-				if (li.listener != null && li.listener.equals(listener)){
-					info = li;
-					break;
-				}
-			}
-		}
-		
-		return info;
-	}
-	
+        Response response = messageEngine.callService(device, serviceCall);
+        if (response == null) {
+            throw new NotifyException("No response received during register process.");
+        } else if (response.getError() != null && !response.getError().isEmpty()) {
+            throw new NotifyException(response.getError());
+        }
+    }
+
+    private void addExtraParameters(Map<String, Object> parameters, Call serviceCall) throws NotifyException {
+        if (parameters != null) {
+            for (String key : parameters.keySet()) {
+                if (key.equalsIgnoreCase(REGISTER_EVENT_LISTENER_EVENT_KEY_PARAMETER))
+                    throw new NotifyException("Can't use reserved keys as parameters for registerForEvent");
+                serviceCall.addParameter(key, parameters.get(key));
+            }
+        }
+    }
+
+    /**
+     * Removes a listener for receiving Notify events and notifies the event driver of its removal.
+     *
+     * @param listener   Listener to be removed.
+     * @param driver     Driver from which the listener must be removed (If not informed all drivers will be considered).
+     * @param instanceId InstanceId from the Driver which the listener must be removed (If not informed all instances will be considered).
+     * @param eventKey   EventKey from which the listener must be removed (If not informed all events will be considered).
+     * @throws NotifyException
+     */
+    public void unregister(
+            UosEventListener listener,
+            UpDevice device,
+            String driver,
+            String instanceId,
+            String eventKey) throws NotifyException {
+
+        NotifyException e = null;
+        Map<UpDevice, Set<EventFilter>> devices = listenerDao.remove(listener, device, driver, instanceId, eventKey);
+        for (Map.Entry<UpDevice, Set<EventFilter>> entry : devices.entrySet()) {
+            for (EventFilter filter : entry.getValue()) {
+                try {
+                    Call serviceCall = new Call(filter.driver, UNREGISTER_LISTENER_SERVICE, filter.id);
+                    serviceCall.addParameter(REGISTER_EVENT_LISTENER_EVENT_KEY_PARAMETER, filter.key);
+                    Response response = messageEngine.callService(entry.getKey(), serviceCall);
+                    if (response == null || (response.getError() != null && !response.getError().isEmpty()))
+                        throw new NotifyException(response.getError());
+                } catch (NotifyException ex) {
+                    logger.log(Level.SEVERE, "Failed to unregister for event: " + filter, ex);
+                    e = ex;
+                }
+            }
+        }
+
+        // In case of an error, throw it
+        if (e != null)
+            throw e;
+    }
+
+    public void handleNofify(Notify notify, UpDevice device) {
+        Set<UosEventListener> listeners = listenerDao.list(device, notify.getDriver(), notify.getInstanceId(), notify.getEventKey());
+        if (listeners.isEmpty()) {
+            logger.fine("No listeners waiting for notify events.");
+            return;
+        }
+        for (UosEventListener listener : listeners)
+            listener.handleEvent(notify);
+    }
+
+    /**
+     * If any of the entries in this data object is not null, it acts as a restriction. If it's null, all values
+     * for that entry are accepted.
+     */
+    private static class EventFilter {
+        UpDevice device;
+        String driver;
+        String id;
+        String key;
+
+        public EventFilter(UpDevice device, String driver, String id, String key) {
+            this.device = device;
+            this.driver = driver;
+            this.id = id;
+            this.key = key;
+        }
+
+        public boolean accepts(UpDevice deviceToCheck, String driverToCheck, String idToCheck, String keyToCheck) {
+            if ((device != null) && (!device.equals(deviceToCheck)))
+                return false;
+            if ((driver != null) && (!driver.equals(driverToCheck)))
+                return false;
+            if ((id != null) && (!id.equals(idToCheck)))
+                return false;
+            if ((key != null) && (!key.equals(keyToCheck)))
+                return false;
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = chainHashCode(0, this.device);
+            hash = chainHashCode(hash, this.driver);
+            hash = chainHashCode(hash, this.id);
+            hash = chainHashCode(hash, this.key);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (!(obj instanceof EventFilter))
+                return false;
+
+            EventFilter other = (EventFilter) obj;
+            return Objects.equals(device, other.device)
+                    && Objects.equals(driver, other.driver)
+                    && Objects.equals(id, other.id)
+                    && Objects.equals(key, other.key);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(device != null ? device.getName() : "*");
+            sb.append("/");
+            sb.append(driver != null ? driver : "*");
+            sb.append("/");
+            sb.append(id != null ? id : "*");
+            sb.append("/");
+            sb.append(key != null ? key : "*");
+            return sb.toString();
+        }
+    }
+
+    private static class ListenerDao {
+        private Map<EventFilter, Set<UosEventListener>> data;
+
+        public ListenerDao() {
+            data = new HashMap<EventFilter, Set<UosEventListener>>();
+        }
+
+        public void insert(UosEventListener listener, EventFilter filter) {
+            Set<UosEventListener> listeners = data.get(filter);
+            if (listeners == null)
+                listeners = new HashSet<UosEventListener>();
+
+            listeners.add(listener);
+            data.put(filter, listeners);
+        }
+
+        public Set<UosEventListener> list(UpDevice device, String driver, String instanceId, String eventKey) {
+            Set<UosEventListener> result = new HashSet<UosEventListener>();
+
+            // Witch entries have a filter that accepts these parameters?
+            for (Map.Entry<EventFilter, Set<UosEventListener>> filterToListeners : data.entrySet())
+                if (filterToListeners.getKey().accepts(device, driver, instanceId, eventKey))
+                    result.addAll(filterToListeners.getValue());
+
+            return result;
+        }
+
+        public Map<UpDevice, Set<EventFilter>> remove(UosEventListener listener, UpDevice device, String driver, String instanceId, String eventKey) {
+            Map<UpDevice, Set<EventFilter>> result = new HashMap<UpDevice, Set<EventFilter>>();
+            EventFilter query = new EventFilter(device, driver, instanceId, eventKey);
+
+            // Witch entries have a filter that accepts these parameters?
+            Iterator<Map.Entry<EventFilter, Set<UosEventListener>>> i = data.entrySet().iterator();
+            while (i.hasNext()) {
+                Map.Entry<EventFilter, Set<UosEventListener>> entry = i.next();
+                EventFilter filter = entry.getKey();
+                Set<UosEventListener> filterListeners = entry.getValue();
+                if (query.accepts(filter.device, filter.driver, filter.id, filter.key)) {
+                    // Removes the listener and stores the device, if not null.
+                    if (filterListeners.remove(listener) && (filter.device != null)) {
+                        Set<EventFilter> deviceFilters = result.get(filter.device);
+                        if (deviceFilters == null)
+                            deviceFilters = new HashSet<EventFilter>();
+                        deviceFilters.add(filter);
+                        result.put(filter.device, deviceFilters);
+                    }
+                    // Clears empty filter sets.
+                    if (filterListeners.isEmpty())
+                        i.remove();
+                }
+            }
+            return result;
+        }
+    }
 }

--- a/src/org/unbiquitous/uos/core/deviceManager/DeviceListener.java
+++ b/src/org/unbiquitous/uos/core/deviceManager/DeviceListener.java
@@ -1,0 +1,25 @@
+package org.unbiquitous.uos.core.deviceManager;
+
+import org.unbiquitous.uos.core.messageEngine.dataType.UpDevice;
+
+/**
+ * Interested listeners must implement this interface to be notified by the device manager of device registration
+ * related events.
+ *
+ * @author Luciano Santos
+ */
+public interface DeviceListener {
+    /**
+     * Called when a device is successfully registered in the device manager.
+     *
+     * @param device A reference to the device has just entered the smart-space.
+     */
+    void deviceRegistered(UpDevice device);
+
+    /**
+     * Called when a previously knwon device is unregistered in the device manager.
+     *
+     * @param device A reference to the device has just left the smart-space.
+     */
+    void deviceUnregistered(UpDevice device);
+}

--- a/src/org/unbiquitous/uos/core/deviceManager/DeviceManager.java
+++ b/src/org/unbiquitous/uos/core/deviceManager/DeviceManager.java
@@ -1,6 +1,7 @@
 package org.unbiquitous.uos.core.deviceManager;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -37,331 +38,371 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 /**
  * Class responsible for managing the devices in the neighborhood of the current
  * device.
- * 
+ *
  * @author Fabricio Nogueira Buzeto
- * 
  */
 public class DeviceManager implements RadarListener {
 
-	private static final String DEVICE_DRIVER_NAME = "uos.DeviceDriver";
+    private static final String DEVICE_DRIVER_NAME = "uos.DeviceDriver";
 
-	private static final String DRIVERS_NAME_KEY = "driversName";
+    private static final String DRIVERS_NAME_KEY = "driversName";
 
-	private static final String INTERFACES_KEY = "interfaces";
+    private static final String INTERFACES_KEY = "interfaces";
 
-	private static final Logger logger = UOSLogging.getLogger();
-	private static final ObjectMapper mapper = new ObjectMapper();
+    private static final Logger logger = UOSLogging.getLogger();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-	private Gateway gateway;
+    private Gateway gateway;
 
-	private ConnectionManagerControlCenter connectionManagerControlCenter;
+    private ConnectionManagerControlCenter connectionManagerControlCenter;
 
-	private DeviceDao deviceDao;
+    private DeviceDao deviceDao;
 
-	private UpDevice currentDevice;
+    private UpDevice currentDevice;
 
-	private ConnectivityManager connectivityManager;
+    private ConnectivityManager connectivityManager;
 
-	private DriverManager driverManager;
+    private DriverManager driverManager;
 
-	private Set<String> unknownDrivers;
+    private Set<String> unknownDrivers;
 
-	private Set<DriverModel> dependents;
+    private Set<DriverModel> dependents;
 
-	public DeviceManager(UpDevice currentDevice, DeviceDao deviceDao, DriverDao driverDao,
-			ConnectionManagerControlCenter connectionManagerControlCenter, ConnectivityManager connectivityManager,
-			Gateway gateway, DriverManager driverManager) {
-		this.gateway = gateway;
-		this.connectionManagerControlCenter = connectionManagerControlCenter;
-		this.currentDevice = currentDevice;
-		this.connectivityManager = connectivityManager;
-		this.deviceDao = deviceDao;
-		this.deviceDao.save(currentDevice);
-		this.driverManager = driverManager;
-		this.unknownDrivers = new HashSet<String>();
-		this.dependents = new HashSet<DriverModel>();
-	}
+    private Set<DeviceListener> deviceListeners;
 
-	/**
-	 * Method responsible for registering a device in the neighborhood of the
-	 * current device.
-	 * 
-	 * @param device
-	 *            Device to be registered.
-	 */
-	public void registerDevice(UpDevice device) {
-		deviceDao.save(device);
-	}
+    public DeviceManager(UpDevice currentDevice, DeviceDao deviceDao, DriverDao driverDao,
+                         ConnectionManagerControlCenter connectionManagerControlCenter, ConnectivityManager connectivityManager,
+                         Gateway gateway, DriverManager driverManager) {
+        this.gateway = gateway;
+        this.connectionManagerControlCenter = connectionManagerControlCenter;
+        this.currentDevice = currentDevice;
+        this.connectivityManager = connectivityManager;
+        this.deviceDao = deviceDao;
+        this.deviceDao.save(currentDevice);
+        this.driverManager = driverManager;
+        this.unknownDrivers = new HashSet<String>();
+        this.dependents = new HashSet<DriverModel>();
+        this.deviceListeners = new HashSet<DeviceListener>();
+    }
 
-	/**
-	 * Method responsible for finding the data about a device present in the
-	 * neighborhood.
-	 * 
-	 * @param deviceName
-	 *            Device name to be found.
-	 * @return <code>UpDevice</code> with the data about the informed device.
-	 */
-	public UpDevice retrieveDevice(String deviceName) {
-		return deviceDao.find(deviceName);
-	}
+    /**
+     * Method responsible for registering a device in the neighborhood of the
+     * current device.
+     *
+     * @param device Device to be registered.
+     */
+    public void registerDevice(UpDevice device) {
+        deviceDao.save(device);
+    }
 
-	/**
-	 * Method responsible for finding the data about a device present in the
-	 * neighborhood.
-	 * 
-	 * @param networkAddress
-	 *            Address of the Device to be found.
-	 * @param networkType
-	 *            NetworkType of Address of the Device to be found.
-	 * @return <code>UpDevice</code> with the data about the informed device.
-	 */
-	public UpDevice retrieveDevice(String networkAddress, String networkType) {
-		List<UpDevice> list = deviceDao.list(networkAddress, networkType);
-		if (list != null && !list.isEmpty()) {
-			UpDevice deviceFound = list.get(0);
-			logger.fine("Device with addr '" + networkAddress + "' found on network '" + networkType + "' resolved to "
-					+ deviceFound);
-			return deviceFound;
-		}
-		logger.fine("No device found with addr '" + networkAddress + "' on network '" + networkType + "'.");
-		return null;
-	}
+    /**
+     * Method responsible for finding the data about a device present in the
+     * neighborhood.
+     *
+     * @param deviceName Device name to be found.
+     * @return <code>UpDevice</code> with the data about the informed device.
+     */
+    public UpDevice retrieveDevice(String deviceName) {
+        return deviceDao.find(deviceName);
+    }
 
-	/**
-	 * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceEntered(org.unbiquitous.uos.core.network.model.NetworkDevice)
-	 */
-	@Override
-	public void deviceEntered(NetworkDevice device) {
-		if (device == null)
-			return;
+    /**
+     * Method responsible for finding the data about a device present in the
+     * neighborhood.
+     *
+     * @param networkAddress Address of the Device to be found.
+     * @param networkType    NetworkType of Address of the Device to be found.
+     * @return <code>UpDevice</code> with the data about the informed device.
+     */
+    public UpDevice retrieveDevice(String networkAddress, String networkType) {
+        List<UpDevice> list = deviceDao.list(networkAddress, networkType);
+        if (list != null && !list.isEmpty()) {
+            UpDevice deviceFound = list.get(0);
+            logger.fine("Device with addr '" + networkAddress + "' found on network '" + networkType + "' resolved to "
+                    + deviceFound);
+            return deviceFound;
+        }
+        logger.fine("No device found with addr '" + networkAddress + "' on network '" + networkType + "'.");
+        return null;
+    }
 
-		// verify if device entered is the current device
-		String deviceHost = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
-		for (UpNetworkInterface networkInterface : this.currentDevice.getNetworks()) {
-			String currentDeviceHost = connectionManagerControlCenter.getHost(networkInterface.getNetworkAddress());
-			if (deviceHost != null && deviceHost.equals(currentDeviceHost)) {
-				logger.fine("Host of device entered is the same of current device:" + device.getNetworkDeviceName());
-				return;
-			}
-		}
+    /**
+     * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceEntered(org.unbiquitous.uos.core.network.model.NetworkDevice)
+     */
+    @Override
+    public void deviceEntered(NetworkDevice device) {
+        if (device == null)
+            return;
 
-		// verify if already know this device.
-		UpDevice upDevice = retrieveDevice(deviceHost, device.getNetworkDeviceType());
+        // verify if device entered is the current device
+        String deviceHost = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
+        for (UpNetworkInterface networkInterface : this.currentDevice.getNetworks()) {
+            String currentDeviceHost = connectionManagerControlCenter.getHost(networkInterface.getNetworkAddress());
+            if (deviceHost != null && deviceHost.equals(currentDeviceHost)) {
+                logger.fine("Host of device entered is the same of current device:" + device.getNetworkDeviceName());
+                return;
+            }
+        }
 
-		if (upDevice == null) {
-			upDevice = doHandshake(device, upDevice);
-			if (upDevice != null) {
-				doDriversRegistry(device, upDevice);
-			}
-		} else {
-			logger.fine("Already known device " + device.getNetworkDeviceName());
-		}
-	}
+        // verify if already know this device.
+        UpDevice upDevice = retrieveDevice(deviceHost, device.getNetworkDeviceType());
 
-	private void doDriversRegistry(NetworkDevice device, UpDevice upDevice) {
-		try {
-			Response response = gateway.callService(upDevice, new Call(DEVICE_DRIVER_NAME, "listDrivers"));
-			if (response != null && response.getResponseData() != null
-					&& response.getResponseData("driverList") != null) {
-				try {
-					ObjectNode driversListMap = null;
-					Object temp = response.getResponseData("driverList");
-					if (temp instanceof ObjectNode)
-						driversListMap = (ObjectNode) temp; // TODO: Not tested, why?
-					else
-						driversListMap = (ObjectNode) mapper.readTree(temp.toString());
+        if (upDevice == null) {
+            upDevice = doHandshake(device, upDevice);
+            if (upDevice != null) {
+                doDriversRegistry(device, upDevice);
+            }
+        } else {
+            logger.fine("Already known device " + device.getNetworkDeviceName());
+        }
+    }
 
-					List<String> ids = new ArrayList<String>();
-					Iterator<String> it = driversListMap.fieldNames();
-					while (it.hasNext())
-						ids.add(it.next());
+    private void doDriversRegistry(NetworkDevice device, UpDevice upDevice) {
+        try {
+            Response response = gateway.callService(upDevice, new Call(DEVICE_DRIVER_NAME, "listDrivers"));
+            if (response != null && response.getResponseData() != null
+                    && response.getResponseData("driverList") != null) {
+                try {
+                    ObjectNode driversListMap = null;
+                    Object temp = response.getResponseData("driverList");
+                    if (temp instanceof ObjectNode)
+                        driversListMap = (ObjectNode) temp; // TODO: Not tested, why?
+                    else
+                        driversListMap = (ObjectNode) mapper.readTree(temp.toString());
 
-					registerRemoteDriverInstances(upDevice, driversListMap, ids);
-				} catch (IOException e) {
-					logger.log(Level.SEVERE,
-							"Problems ocurred in the registering of drivers from device '" + upDevice.getName() + "' .",
-							e);
-				}
-			}
-		} catch (Exception e) {
-			logger.severe("Not possible to discover services from device '" + device.getNetworkDeviceName()
-					+ "'. Possibly not a uOS Device");
-		}
-	}
+                    List<String> ids = new ArrayList<String>();
+                    Iterator<String> it = driversListMap.fieldNames();
+                    while (it.hasNext())
+                        ids.add(it.next());
 
-	private void registerRemoteDriverInstances(UpDevice upDevice, ObjectNode driversListMap, List<String> instanceIds)
-			throws IOException {
-		for (String id : instanceIds) {
-			UpDriver upDriver = mapper.readValue(mapper.writeValueAsString(driversListMap.get(id)), UpDriver.class);
-			DriverModel driverModel = new DriverModel(id, upDriver, upDevice.getName());
+                    registerRemoteDriverInstances(upDevice, driversListMap, ids);
+                } catch (IOException e) {
+                    logger.log(Level.SEVERE,
+                            "Problems ocurred in the registering of drivers from device '" + upDevice.getName() + "' .",
+                            e);
+                }
+            }
+        } catch (Exception e) {
+            logger.severe("Not possible to discover services from device '" + device.getNetworkDeviceName()
+                    + "'. Possibly not a uOS Device");
+        }
+    }
 
-			try {
-				driverManager.insert(driverModel);
-				// TODO : DeviceManager : Save the device information
-				if (this.connectivityManager.doProxying()) {
-					this.connectivityManager.registerProxyDriver(upDriver, upDevice, id);
-				}
-			} catch (DriverManagerException e) {
-				logger.log(Level.SEVERE,
-						"Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
-								+ id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
-						e);
-			} catch (DriverNotFoundException e) {
-				unknownDrivers.addAll(e.getDriversName());
-				dependents.add(driverModel);
+    private void registerRemoteDriverInstances(UpDevice upDevice, ObjectNode driversListMap, List<String> instanceIds)
+            throws IOException {
+        for (String id : instanceIds) {
+            UpDriver upDriver = mapper.readValue(mapper.writeValueAsString(driversListMap.get(id)), UpDriver.class);
+            DriverModel driverModel = new DriverModel(id, upDriver, upDevice.getName());
 
-			} catch (RuntimeException e) {
-				logger.log(Level.SEVERE,
-						"Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
-								+ id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
-						e);
-			}
-		}
-		if (unknownDrivers.size() > 0)
-			findDrivers(unknownDrivers, upDevice);
-	}
+            try {
+                driverManager.insert(driverModel);
+                // TODO : DeviceManager : Save the device information
+                if (this.connectivityManager.doProxying()) {
+                    this.connectivityManager.registerProxyDriver(upDriver, upDevice, id);
+                }
+            } catch (DriverManagerException e) {
+                logger.log(Level.SEVERE,
+                        "Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
+                                + id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
+                        e);
+            } catch (DriverNotFoundException e) {
+                unknownDrivers.addAll(e.getDriversName());
+                dependents.add(driverModel);
 
-	/**
-	 * @param upDevice
-	 * @param e
-	 * @return
-	 * @throws JSONException
-	 * @throws ServiceCallException
-	 */
-	private void findDrivers(Set<String> unknownDrivers, UpDevice upDevice) throws IOException {
-		Call call = new Call(DEVICE_DRIVER_NAME, "tellEquivalentDrivers", null);
-		call.addParameter(DRIVERS_NAME_KEY, mapper.writeValueAsString(unknownDrivers.toArray()));
+            } catch (RuntimeException e) {
+                logger.log(Level.SEVERE,
+                        "Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
+                                + id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
+                        e);
+            }
+        }
+        if (unknownDrivers.size() > 0)
+            findDrivers(unknownDrivers, upDevice);
+    }
 
-		try {
-			Response equivalentDriverResponse = gateway.callService(upDevice, call);
+    /**
+     * @param upDevice
+     * @param e
+     * @return
+     * @throws JSONException
+     * @throws ServiceCallException
+     */
+    private void findDrivers(Set<String> unknownDrivers, UpDevice upDevice) throws IOException {
+        Call call = new Call(DEVICE_DRIVER_NAME, "tellEquivalentDrivers", null);
+        call.addParameter(DRIVERS_NAME_KEY, mapper.writeValueAsString(unknownDrivers.toArray()));
 
-			if (equivalentDriverResponse != null
-					&& (equivalentDriverResponse.getError() == null || equivalentDriverResponse.getError().isEmpty())) {
+        try {
+            Response equivalentDriverResponse = gateway.callService(upDevice, call);
 
-				String interfaces = equivalentDriverResponse.getResponseString(INTERFACES_KEY);
+            if (equivalentDriverResponse != null
+                    && (equivalentDriverResponse.getError() == null || equivalentDriverResponse.getError().isEmpty())) {
 
-				if (interfaces != null) {
+                String interfaces = equivalentDriverResponse.getResponseString(INTERFACES_KEY);
 
-					List<UpDriver> drivers = new ArrayList<UpDriver>();
+                if (interfaces != null) {
 
-					ArrayNode interfacesJson = (ArrayNode) mapper.readTree(interfaces);
-					for (JsonNode node : interfacesJson) {
-						UpDriver upDriver = mapper.readValue(node.isTextual() ? node.asText() : node.toString(), UpDriver.class);
-						drivers.add(upDriver);
-					}
+                    List<UpDriver> drivers = new ArrayList<UpDriver>();
 
-					try {
-						driverManager.addToEquivalenceTree(drivers);
-					} catch (InterfaceValidationException e) {
-						logger.severe("Not possible to add to equivalance tree due to wrong interface specification.");
-					}
+                    ArrayNode interfacesJson = (ArrayNode) mapper.readTree(interfaces);
+                    for (JsonNode node : interfacesJson) {
+                        UpDriver upDriver = mapper.readValue(node.isTextual() ? node.asText() : node.toString(), UpDriver.class);
+                        drivers.add(upDriver);
+                    }
 
-					for (DriverModel dependent : dependents) {
-						try {
-							driverManager.insert(dependent);
-						} catch (DriverManagerException e) {
-							logger.log(Level.SEVERE,
-									"Problems ocurred in the registering of driver '" + dependent.driver().getName()
-											+ "' with instanceId '" + dependent.id() + "' in the device '"
-											+ upDevice.getName() + "' and it will not be registered.",
-									e);
-						} catch (DriverNotFoundException e) {
-							logger.severe("Not possible to register driver '" + dependent.driver().getName()
-									+ "' due to unkwnown equivalent driver.");
-						}
-					}
+                    try {
+                        driverManager.addToEquivalenceTree(drivers);
+                    } catch (InterfaceValidationException e) {
+                        logger.severe("Not possible to add to equivalance tree due to wrong interface specification.");
+                    }
 
-				} else {
-					logger.severe("Not possible to call service on device '" + upDevice.getName()
-							+ "' for no equivalent drivers on the service response.");
-				}
-			} else {
-				logger.severe("Not possible to call service on device '" + upDevice.getName()
-						+ (equivalentDriverResponse == null ? ": null"
-								: "': Cause : " + equivalentDriverResponse.getError()));
-			}
-		} catch (ServiceCallException e) {
-			logger.severe("Not possible to call service on device '" + upDevice.getName());
-		}
-	}
+                    for (DriverModel dependent : dependents) {
+                        try {
+                            driverManager.insert(dependent);
+                        } catch (DriverManagerException e) {
+                            logger.log(Level.SEVERE,
+                                    "Problems ocurred in the registering of driver '" + dependent.driver().getName()
+                                            + "' with instanceId '" + dependent.id() + "' in the device '"
+                                            + upDevice.getName() + "' and it will not be registered.",
+                                    e);
+                        } catch (DriverNotFoundException e) {
+                            logger.severe("Not possible to register driver '" + dependent.driver().getName()
+                                    + "' due to unkwnown equivalent driver.");
+                        }
+                    }
 
-	@SuppressWarnings("rawtypes")
-	private UpDevice doHandshake(NetworkDevice device, UpDevice upDevice) {
-		try {
-			// Create a Dummy device just for calling it
-			logger.fine("Trying to hanshake with device : " + device.getNetworkDeviceName());
-			UpDevice dummyDevice = new UpDevice(device.getNetworkDeviceName())
-					.addNetworkInterface(device.getNetworkDeviceName(), device.getNetworkDeviceType());
+                } else {
+                    logger.severe("Not possible to call service on device '" + upDevice.getName()
+                            + "' for no equivalent drivers on the service response.");
+                }
+            } else {
+                logger.severe("Not possible to call service on device '" + upDevice.getName()
+                        + (equivalentDriverResponse == null ? ": null"
+                        : "': Cause : " + equivalentDriverResponse.getError()));
+            }
+        } catch (ServiceCallException e) {
+            logger.severe("Not possible to call service on device '" + upDevice.getName());
+        }
+    }
 
-			Call call = new Call(DEVICE_DRIVER_NAME, "handshake", null);
-			call.addParameter("device", mapper.writeValueAsString(currentDevice));
+    @SuppressWarnings("rawtypes")
+    private UpDevice doHandshake(NetworkDevice device, UpDevice upDevice) {
+        try {
+            // Create a Dummy device just for calling it
+            logger.fine("Trying to hanshake with device : " + device.getNetworkDeviceName());
+            UpDevice dummyDevice = new UpDevice(device.getNetworkDeviceName())
+                    .addNetworkInterface(device.getNetworkDeviceName(), device.getNetworkDeviceType());
 
-			Response response = gateway.callService(dummyDevice, call);
-			if (response != null && (response.getError() == null || response.getError().isEmpty())) {
-				// in case of a success greeting process, register the device in
-				// the neighborhood database
-				Object responseDevice = response.getResponseData("device");
-				if (responseDevice != null) {
-					UpDevice remoteDevice;
-					if (responseDevice instanceof String) {
-						remoteDevice = mapper.readValue((String) responseDevice, UpDevice.class);
-					} else if (responseDevice instanceof Map) {
-						remoteDevice = mapper.treeToValue(mapper.valueToTree((Map) responseDevice), UpDevice.class);
-					} else {
-						remoteDevice = mapper.treeToValue((JsonNode) responseDevice, UpDevice.class);
-					}
-					registerDevice(remoteDevice);
-					logger.info("Registered device " + remoteDevice.getName());
-					return remoteDevice;
-				} else {
-					logger.severe("Not possible complete handshake with device '" + device.getNetworkDeviceName()
-							+ "' for no device on the handshake response.");
-				}
-			} else {
-				logger.severe("Not possible to handshake with device '" + device.getNetworkDeviceName()
-						+ (response == null ? ": No Response received." : "': Cause : " + response.getError()));
-			}
-		} catch (Exception e) {
-			logger.severe(
-					"Not possible to handshake with device '" + device.getNetworkDeviceName() + "'. " + e.getMessage());
-		}
-		return upDevice;
-	}
+            Call call = new Call(DEVICE_DRIVER_NAME, "handshake", null);
+            call.addParameter("device", mapper.writeValueAsString(currentDevice));
 
-	/**
-	 * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceLeft(org.unbiquitous.uos.core.network.model.NetworkDevice)
-	 */
-	@Override
-	public void deviceLeft(NetworkDevice device) {
-		if (device == null || device.getNetworkDeviceName() == null || device.getNetworkDeviceType() == null)
-			return;
-		// Remove what services this device has.
-		logger.info(
-				"Device " + device.getNetworkDeviceName() + " of type " + device.getNetworkDeviceType() + " leaving.");
-		String host = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
-		List<UpDevice> devices = deviceDao.list(host, device.getNetworkDeviceType());
+            Response response = gateway.callService(dummyDevice, call);
+            if (response != null && (response.getError() == null || response.getError().isEmpty())) {
+                // in case of a success greeting process, register the device in
+                // the neighborhood database
+                Object responseDevice = response.getResponseData("device");
+                if (responseDevice != null) {
+                    UpDevice remoteDevice;
+                    if (responseDevice instanceof String) {
+                        remoteDevice = mapper.readValue((String) responseDevice, UpDevice.class);
+                    } else if (responseDevice instanceof Map) {
+                        remoteDevice = mapper.treeToValue(mapper.valueToTree((Map) responseDevice), UpDevice.class);
+                    } else {
+                        remoteDevice = mapper.treeToValue((JsonNode) responseDevice, UpDevice.class);
+                    }
+                    registerDevice(remoteDevice);
+                    fireDeviceEvent(remoteDevice, DeviceEventType.ENTERED);
+                    logger.info("Registered device " + remoteDevice.getName());
+                    return remoteDevice;
+                } else {
+                    logger.severe("Not possible complete handshake with device '" + device.getNetworkDeviceName()
+                            + "' for no device on the handshake response.");
+                }
+            } else {
+                logger.severe("Not possible to handshake with device '" + device.getNetworkDeviceName()
+                        + (response == null ? ": No Response received." : "': Cause : " + response.getError()));
+            }
+        } catch (Exception e) {
+            logger.severe(
+                    "Not possible to handshake with device '" + device.getNetworkDeviceName() + "'. " + e.getMessage());
+        }
+        return upDevice;
+    }
 
-		if (devices != null && !devices.isEmpty()) {
-			UpDevice upDevice = devices.get(0);
-			List<DriverModel> returnedDrivers = driverManager.list(null, upDevice.getName());
-			if (returnedDrivers != null && !returnedDrivers.isEmpty()) {
-				for (DriverModel rdd : returnedDrivers) {
-					driverManager.delete(rdd.id(), rdd.device());
-				}
-			}
-			deviceDao.delete(upDevice.getName());
-			logger.info(String.format("Device '%s' left", upDevice.getName()));
-		} else {
-			logger.info("Device not found in database.");
-		}
+    /**
+     * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceLeft(org.unbiquitous.uos.core.network.model.NetworkDevice)
+     */
+    @Override
+    public void deviceLeft(NetworkDevice device) {
+        if (device == null || device.getNetworkDeviceName() == null || device.getNetworkDeviceType() == null)
+            return;
+        // Remove what services this device has.
+        logger.info(
+                "Device " + device.getNetworkDeviceName() + " of type " + device.getNetworkDeviceType() + " leaving.");
+        String host = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
+        List<UpDevice> devices = deviceDao.list(host, device.getNetworkDeviceType());
 
-	}
+        if (devices != null && !devices.isEmpty()) {
+            UpDevice upDevice = devices.get(0);
+            List<DriverModel> returnedDrivers = driverManager.list(null, upDevice.getName());
+            if (returnedDrivers != null && !returnedDrivers.isEmpty()) {
+                for (DriverModel rdd : returnedDrivers) {
+                    driverManager.delete(rdd.id(), rdd.device());
+                }
+            }
+            deviceDao.delete(upDevice.getName());
+            fireDeviceEvent(upDevice, DeviceEventType.LEFT);
+            logger.info(String.format("Device '%s' left", upDevice.getName()));
+        } else {
+            logger.info("Device not found in database.");
+        }
+    }
 
-	public List<UpDevice> listDevices() {
-		return deviceDao.list();
-	}
+    public List<UpDevice> listDevices() {
+        return deviceDao.list();
+    }
 
-	public DeviceDao getDeviceDao() {
-		return deviceDao;
-	}
+    public DeviceDao getDeviceDao() {
+        return deviceDao;
+    }
+
+    /**
+     * Adds a new listener to the device manager, that will be notified whenever a previously unknown device is
+     * successfully registered or a previously registered device is unregistered due to leaving the smartspace.
+     *
+     * @param listener the new listener to be added.
+     * @throws NullPointerException if listener is null.
+     */
+    public void addDeviceListener(DeviceListener listener) {
+        if (listener == null)
+            throw new NullPointerException("listener");
+        deviceListeners.add(listener);
+    }
+
+    /**
+     * Removes a previously added listener. If listener is null or was not previously added,
+     * nothing happens.
+     *
+     * @param listener the listener to be removed.
+     */
+    public void removeDeviceListener(DeviceListener listener) {
+        deviceListeners.remove(listener);
+    }
+
+    private enum DeviceEventType {ENTERED, LEFT}
+
+    private void fireDeviceEvent(UpDevice device, DeviceEventType type) {
+        try {
+            Method m = ((type == DeviceEventType.ENTERED) ?
+                    DeviceListener.class.getMethod("deviceRegistered", UpDevice.class) :
+                    DeviceListener.class.getMethod("deviceUnregistered", UpDevice.class));
+            for (DeviceListener l : deviceListeners)
+                try {
+                    m.invoke(l, device);
+                } catch (Throwable t) {
+                    logger.log(Level.WARNING, "Failed to notify device listener of event.", t);
+                }
+        } catch (NoSuchMethodException e) {
+            logger.log(Level.SEVERE, "Failed to load DeviceListener methods.", e);
+        }
+    }
 }

--- a/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
+++ b/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
@@ -154,13 +154,15 @@ public class DeviceDriver implements UosDriver {
         DeviceManager deviceManager = gtw.getDeviceManager();
 
         // Get and Convert the UpDevice Parameter
-        String deviceParameter = (String) serviceCall.getParameterString(DEVICE_KEY);
+        Object deviceParameter = serviceCall.getParameter(DEVICE_KEY);
         if (deviceParameter == null) {
             serviceResponse.setError("No 'device' parameter informed.");
             return;
         }
         try {
-            UpDevice device = mapper.readValue(deviceParameter, UpDevice.class);
+            UpDevice device = deviceParameter instanceof String ?
+                    mapper.readValue((String) deviceParameter, UpDevice.class) :
+                    mapper.convertValue(deviceParameter, UpDevice.class);
             // TODO : DeviceDriver : validate if the device doing the handshake
             // is the same that is in the parameter
             deviceManager.registerDevice(device);

--- a/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
+++ b/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
@@ -1,12 +1,8 @@
 package org.unbiquitous.uos.core.driver;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.unbiquitous.uos.core.AuthenticationHandler;
 import org.unbiquitous.uos.core.InitialProperties;
 import org.unbiquitous.uos.core.UOSLogging;
@@ -24,218 +20,213 @@ import org.unbiquitous.uos.core.messageEngine.dataType.UpService;
 import org.unbiquitous.uos.core.messageEngine.messages.Call;
 import org.unbiquitous.uos.core.messageEngine.messages.Response;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Driver responsible for providing information about the device.
- * 
- * @author Fabricio Nogueira Buzeto
  *
+ * @author Fabricio Nogueira Buzeto
  */
 public class DeviceDriver implements UosDriver {
-	private static Logger logger = UOSLogging.getLogger();
-	private static final ObjectMapper mapper = new ObjectMapper();
+    private static Logger logger = UOSLogging.getLogger();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-	private static final String DEVICE_KEY = "device";
-	private static final String SECURITY_TYPE_KEY = "securityType";
-	private static final String DRIVER_LIST_KEY = "driverList";
-	private static final String DRIVER_NAME_KEY = "driverName";
-	private static final String INTERFACES_KEY = "interfaces";
-	private static final String DRIVERS_NAME_KEY = "driversName";
+    private static final String DEVICE_KEY = "device";
+    private static final String SECURITY_TYPE_KEY = "securityType";
+    private static final String DRIVER_LIST_KEY = "driverList";
+    private static final String DRIVER_NAME_KEY = "driverName";
+    private static final String INTERFACES_KEY = "interfaces";
+    private static final String DRIVERS_NAME_KEY = "driversName";
 
-	private Gateway gateway;
-	private final UpDriver driver;
+    private Gateway gateway;
+    private final UpDriver driver;
 
-	public DeviceDriver() {
-		driver = new UpDriver("uos.DeviceDriver");
+    public DeviceDriver() {
+        driver = new UpDriver("uos.DeviceDriver");
 
-		driver.addService("listDrivers").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.OPTIONAL);
+        driver.addService("listDrivers").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.OPTIONAL);
 
-		driver.addService("authenticate").addParameter(SECURITY_TYPE_KEY, UpService.ParameterType.MANDATORY);
+        driver.addService("authenticate").addParameter(SECURITY_TYPE_KEY, UpService.ParameterType.MANDATORY);
 
-		driver.addService("goodbye");
+        driver.addService("goodbye");
 
-		driver.addService("handshake").addParameter(DEVICE_KEY, UpService.ParameterType.MANDATORY);
+        driver.addService("handshake").addParameter(DEVICE_KEY, UpService.ParameterType.MANDATORY);
 
-		driver.addService("tellEquivalentDriver").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.MANDATORY);
-	}
+        driver.addService("tellEquivalentDriver").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.MANDATORY);
+    }
 
-	@Override
-	public UpDriver getDriver() {
-		return driver;
-	}
+    @Override
+    public UpDriver getDriver() {
+        return driver;
+    }
 
-	@Override
-	public void init(Gateway gateway, InitialProperties properties, String instanceId) {
-		this.gateway = gateway;
-	}
+    @Override
+    public void init(Gateway gateway, InitialProperties properties, String instanceId) {
+        this.gateway = gateway;
+    }
 
-	@Override
-	public void destroy() {
-	}
+    @Override
+    public void destroy() {
+    }
 
-	@Override
-	public List<UpDriver> getParent() {
-		return null;
-	}
+    @Override
+    public List<UpDriver> getParent() {
+        return null;
+    }
 
-	/**
-	 * Service responsible for retrieving the list of Driver Instances present
-	 * in the underlying device. This listing service can have its result
-	 * filtered with the use of the parameters 'serviceName' or 'driverName'. It
-	 * responds in a single responseMap within the parameter 'driverList'
-	 */
-	@SuppressWarnings("unchecked")
-	public void listDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		logger.info("Handling DeviceDriverImpl#listDrivers service");
+    /**
+     * Service responsible for retrieving the list of Driver Instances present
+     * in the underlying device. This listing service can have its result
+     * filtered with the use of the parameters 'serviceName' or 'driverName'. It
+     * responds in a single responseMap within the parameter 'driverList'
+     */
+    @SuppressWarnings("unchecked")
+    public void listDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        logger.info("Handling DeviceDriverImpl#listDrivers service");
 
-		List<DriverData> listDrivers = null;
+        List<DriverData> listDrivers = null;
 
-		Map<String, Object> parameters = serviceCall.getParameters();
+        Map<String, Object> parameters = serviceCall.getParameters();
 
-		// handle parameters to filter message
-		DriverManager driverManager = ((SmartSpaceGateway) this.gateway).getDriverManager();
-		if (parameters != null) {
-			listDrivers = driverManager.listDrivers((String) parameters.get(DRIVER_NAME_KEY),
-					this.gateway.getCurrentDevice().getName());
-		} else {
-			// In case no parameters informed, list all drivers
-			listDrivers = driverManager.listDrivers(null, this.gateway.getCurrentDevice().getName());
-		}
+        // handle parameters to filter message
+        DriverManager driverManager = ((SmartSpaceGateway) this.gateway).getDriverManager();
+        if (parameters != null) {
+            listDrivers = driverManager.listDrivers((String) parameters.get(DRIVER_NAME_KEY),
+                    this.gateway.getCurrentDevice().getName());
+        } else {
+            // In case no parameters informed, list all drivers
+            listDrivers = driverManager.listDrivers(null, this.gateway.getCurrentDevice().getName());
+        }
 
-		// If the current device is doing proxy, filter the list of drivers
-		if (((SmartSpaceGateway) this.gateway).getConnectivityManager().doProxying()) {
-			((SmartSpaceGateway) this.gateway).getConnectivityManager().filterDriversList(listDrivers);
-		}
+        // If the current device is doing proxy, filter the list of drivers
+        if (((SmartSpaceGateway) this.gateway).getConnectivityManager().doProxying()) {
+            ((SmartSpaceGateway) this.gateway).getConnectivityManager().filterDriversList(listDrivers);
+        }
 
-		// Converts the list of DriverData into Parameters
-		ObjectNode driversList = mapper.getNodeFactory().objectNode();
-		if (listDrivers != null && !listDrivers.isEmpty()) {
-			for (DriverData driverData : listDrivers)
-				driversList.set(driverData.getInstanceID(), mapper.valueToTree(driverData.getDriver()));
-		}
-		@SuppressWarnings("rawtypes")
-		Map responseData = new HashMap();
+        // Converts the list of DriverData into Parameters
+        final Map<String, Object> driversList = new HashMap<String, Object>();
+        if (listDrivers != null)
+            for (DriverData driverData : listDrivers)
+                driversList.put(driverData.getInstanceID(), driverData.getDriver());
+        serviceResponse.setResponseData(new HashMap<String, Object>() {{
+            put(DRIVER_LIST_KEY, driversList);
+        }});
+    }
 
-		responseData.put(DRIVER_LIST_KEY, driversList);
+    /**
+     * Service responsible for authenticating a device. This Service can be
+     * called multiple times for a authentication process with multiple steps.
+     * The authentication algorithm is determined by the parameter
+     * 'securityType'.
+     */
+    public void authenticate(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        String securityType = (String) serviceCall.getParameters().get(SECURITY_TYPE_KEY);
 
-		serviceResponse.setResponseData(responseData);
-	}
+        // find the Authentication handler responsible for the requested
+        // securityType
+        AuthenticationHandler ah = ((SmartSpaceGateway) this.gateway).getSecurityManager()
+                .getAuthenticationHandler(securityType);
 
-	/**
-	 * Service responsible for authenticating a device. This Service can be
-	 * called multiple times for a authentication process with multiple steps.
-	 * The authentication algorithm is determined by the parameter
-	 * 'securityType'.
-	 */
-	public void authenticate(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        // delegate the authentication process to the AuthenticationHandler
+        // responsible
+        if (ah != null) {
+            ah.authenticate(serviceCall, serviceResponse, messageContext);
+        } else {
+            serviceResponse.setError("No AuthenticationHandler found for the security type : '" + securityType + "' .");
+        }
+    }
 
-		String securityType = (String) serviceCall.getParameters().get(SECURITY_TYPE_KEY);
+    /**
+     * This method is responsible for creating a mutual knowledge of two device
+     * about it's basic informations. This information must be informed in the
+     * parameter 'device'(<code>UpDevice</code>) by the caller device and will
+     * be returned in the same parameter with the information of the called
+     * device.
+     */
+    @SuppressWarnings("unchecked")
+    public void handshake(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        SmartSpaceGateway gtw = (SmartSpaceGateway) this.gateway;
+        DeviceManager deviceManager = gtw.getDeviceManager();
 
-		// find the Authentication handler responsible for the requested
-		// securityType
-		AuthenticationHandler ah = ((SmartSpaceGateway) this.gateway).getSecurityManager()
-				.getAuthenticationHandler(securityType);
+        // Get and Convert the UpDevice Parameter
+        String deviceParameter = (String) serviceCall.getParameterString(DEVICE_KEY);
+        if (deviceParameter == null) {
+            serviceResponse.setError("No 'device' parameter informed.");
+            return;
+        }
+        try {
+            UpDevice device = mapper.readValue(deviceParameter, UpDevice.class);
+            // TODO : DeviceDriver : validate if the device doing the handshake
+            // is the same that is in the parameter
+            deviceManager.registerDevice(device);
+            serviceResponse.addParameter(DEVICE_KEY, mapper.valueToTree(gateway.getCurrentDevice()));
+            Response driversResponse = gateway.callService(device, new Call("uos.DeviceDriver", "listDrivers"));
+            Object driverList = driversResponse.getResponseData("driverList");
+            if (driverList != null) {
+                JavaType mapType = mapper.getTypeFactory().constructParametrizedType(Map.class, Map.class, String.class, UpDriver.class);
+                Map<String, UpDriver> driverMap = mapper.convertValue(driverList, mapType);
+                // TODO: this is duplicated with DeviceManager.registerRemoteDriverInstances
+                for (Map.Entry<String, UpDriver> entry : driverMap.entrySet()) {
+                    DriverModel driverModel = new DriverModel(entry.getKey(), entry.getValue(), device.getName());
+                    gtw.getDriverManager().insert(driverModel);
+                }
+            }
+        } catch (Exception e) {
+            serviceResponse.setError(e.getMessage());
+            logger.log(Level.SEVERE, "Problems on handshake", e);
+        }
+    }
 
-		// delegate the authentication process to the AuthenticationHandler
-		// responsible
-		if (ah != null) {
-			ah.authenticate(serviceCall, serviceResponse, messageContext);
-		} else {
-			serviceResponse.setError("No AuthenticationHandler found for the security type : '" + securityType + "' .");
-		}
+    /**
+     * This method is responsible for informing that the caller device is
+     * leaving the smart-space, so all its data must be removed.
+     */
+    public void goodbye(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        ((SmartSpaceGateway) gateway).getDeviceManager().deviceLeft(messageContext.getCallerNetworkDevice());
+    }
 
-	}
+    /**
+     * This method is responsible for informing the unknown equivalent driverss.
+     */
+    public void tellEquivalentDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        try {
 
-	/**
-	 * This method is responsible for creating a mutual knowledge of two device
-	 * about it's basic informations. This information must be informed in the
-	 * parameter 'device'(<code>UpDevice</code>) by the caller device and will
-	 * be returned in the same parameter with the information of the called
-	 * device.
-	 */
-	@SuppressWarnings("unchecked")
-	public void handshake(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		SmartSpaceGateway gtw = (SmartSpaceGateway) this.gateway;
-		DeviceManager deviceManager = gtw.getDeviceManager();
+            String equivalentDrivers = (String) serviceCall.getParameter(DRIVERS_NAME_KEY);
+            ArrayNode equivalentDriversJson = (ArrayNode) mapper.readTree(equivalentDrivers);
+            ArrayNode jsonList = mapper.getNodeFactory().arrayNode();
+            Map<String, Object> responseData = new HashMap<String, Object>();
+            for (int i = 0; i < equivalentDriversJson.size(); ++i) {
+                String equivalentDriver = equivalentDriversJson.get(i).asText();
+                UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
+                        .getDriverFromEquivalanceTree(equivalentDriver);
+                if (driver != null) {
+                    addToEquivalanceList(jsonList, driver);
+                }
+            }
+            responseData.put(INTERFACES_KEY, jsonList.toString());
+            serviceResponse.setResponseData(responseData);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Problems on equivalent drivers.", e);
+        }
+    }
 
-		// Get and Convert the UpDevice Parameter
-		String deviceParameter = (String) serviceCall.getParameterString(DEVICE_KEY);
-		if (deviceParameter == null) {
-			serviceResponse.setError("No 'device' parameter informed.");
-			return;
-		}
-		try {
-			UpDevice device = mapper.readValue(deviceParameter, UpDevice.class);
-			// TODO : DeviceDriver : validate if the device doing the handshake
-			// is the same that is in the parameter
-			deviceManager.registerDevice(device);
-			serviceResponse.addParameter(DEVICE_KEY, mapper.valueToTree(gateway.getCurrentDevice()));
-			Response driversResponse = gateway.callService(device, new Call("uos.DeviceDriver", "listDrivers"));
-			Object driverList = driversResponse.getResponseData("driverList");
-			if (driverList != null) {
-				Map<String, Object> driverMap = mapper.readValue(driverList.toString(), Map.class);
-				// TODO: this is duplicated with
-				// DeviceManager.registerRemoteDriverInstances
-				for (String id : driverMap.keySet()) {
-					UpDriver upDriver = mapper.readValue(mapper.writeValueAsString(driverMap.get(id)), UpDriver.class);
-					DriverModel driverModel = new DriverModel(id, upDriver, device.getName());
-					gtw.getDriverManager().insert(driverModel);
-				}
-			}
-		} catch (Exception e) {
-			serviceResponse.setError(e.getMessage());
-			logger.log(Level.SEVERE, "Problems on handshake", e);
-		}
-	}
-
-	/**
-	 * This method is responsible for informing that the caller device is
-	 * leaving the smart-space, so all its data must be removed.
-	 */
-	public void goodbye(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		((SmartSpaceGateway) gateway).getDeviceManager().deviceLeft(messageContext.getCallerNetworkDevice());
-	}
-
-	/**
-	 * This method is responsible for informing the unknown equivalent driverss.
-	 */
-	public void tellEquivalentDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		try {
-
-			String equivalentDrivers = (String) serviceCall.getParameter(DRIVERS_NAME_KEY);
-			ArrayNode equivalentDriversJson = (ArrayNode) mapper.readTree(equivalentDrivers);
-			ArrayNode jsonList = mapper.getNodeFactory().arrayNode();
-			Map<String, Object> responseData = new HashMap<String, Object>();
-			for (int i = 0; i < equivalentDriversJson.size(); ++i) {
-				String equivalentDriver = equivalentDriversJson.get(i).asText();
-				UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
-						.getDriverFromEquivalanceTree(equivalentDriver);
-				if (driver != null) {
-					addToEquivalanceList(jsonList, driver);
-				}
-			}
-			responseData.put(INTERFACES_KEY, jsonList.toString());
-			serviceResponse.setResponseData(responseData);
-		} catch (IOException e) {
-			logger.log(Level.SEVERE, "Problems on equivalent drivers.", e);
-		}
-	}
-
-	private void addToEquivalanceList(ArrayNode jsonList, UpDriver upDriver) {
-		List<String> equivalentDrivers = upDriver.getEquivalentDrivers();
-		if (equivalentDrivers != null) {
-			for (String equivalentDriver : equivalentDrivers) {
-				UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
-						.getDriverFromEquivalanceTree(equivalentDriver);
-				if (driver != null) {
-					addToEquivalanceList(jsonList, driver);
-				}
-			}
-		}
-		jsonList.add(mapper.valueToTree(upDriver));
-	}
+    private void addToEquivalanceList(ArrayNode jsonList, UpDriver upDriver) {
+        List<String> equivalentDrivers = upDriver.getEquivalentDrivers();
+        if (equivalentDrivers != null) {
+            for (String equivalentDriver : equivalentDrivers) {
+                UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
+                        .getDriverFromEquivalanceTree(equivalentDriver);
+                if (driver != null) {
+                    addToEquivalanceList(jsonList, driver);
+                }
+            }
+        }
+        jsonList.add(mapper.valueToTree(upDriver));
+    }
 
 }

--- a/src/org/unbiquitous/uos/core/driverManager/DriverData.java
+++ b/src/org/unbiquitous/uos/core/driverManager/DriverData.java
@@ -58,7 +58,7 @@ public class DriverData {
 
     @Override
     public int hashCode() {
-        int hash = chainHashCode(super.hashCode(), this.driver);
+        int hash = chainHashCode(0, this.driver);
         hash = chainHashCode(hash, this.instanceID);
         hash = chainHashCode(hash, this.device);
         return hash;

--- a/src/org/unbiquitous/uos/core/driverManager/DriverData.java
+++ b/src/org/unbiquitous/uos/core/driverManager/DriverData.java
@@ -3,56 +3,64 @@ package org.unbiquitous.uos.core.driverManager;
 import org.unbiquitous.uos.core.messageEngine.dataType.UpDevice;
 import org.unbiquitous.uos.core.messageEngine.dataType.UpDriver;
 
+import static org.unbiquitous.uos.core.ClassLoaderUtils.chainHashCode;
+import static org.unbiquitous.uos.core.ClassLoaderUtils.compare;
+
 /**
  * Entity Responsible for handling the data about Drivers and its services on devices
- * 
- * @author Fabricio Nogueira Buzeto
  *
+ * @author Fabricio Nogueira Buzeto
  */
 public class DriverData {
-	private String instanceID;
-	private UpDriver driver;
-	private UpDevice device; 
-	
-	public DriverData(UpDriver driver, UpDevice device,	String instanceID) {
-		this.driver = driver;
-		this.device = device;
-		this.instanceID = instanceID;
-	}
+    private String instanceID;
+    private UpDriver driver;
+    private UpDevice device;
 
-	public boolean equals(Object obj) {
-		if (obj != null && obj instanceof DriverData){
-			DriverData temp = (DriverData)obj;
-			if (temp.driver != null && 
-					temp.device != null && 
-					temp.instanceID != null){
-				return temp.driver.equals(this.driver) && 
-						temp.device.equals(this.device) &&
-						temp.instanceID.equals(this.instanceID);
-			}
-		}
-		return false;
-	}
+    public DriverData(UpDriver driver, UpDevice device, String instanceID) {
+        this.driver = driver;
+        this.device = device;
+        this.instanceID = instanceID;
+    }
 
-	/**
-	 * @return the instanceID
-	 */
-	public String getInstanceID() {
-		return instanceID;
-	}
+    /**
+     * @return the instanceID
+     */
+    public String getInstanceID() {
+        return instanceID;
+    }
 
-	/**
-	 * @return the driver
-	 */
-	public UpDriver getDriver() {
-		return driver;
-	}
+    /**
+     * @return the driver
+     */
+    public UpDriver getDriver() {
+        return driver;
+    }
 
-	/**
-	 * @return the device
-	 */
-	public UpDevice getDevice() {
-		return device;
-	}
+    /**
+     * @return the device
+     */
+    public UpDevice getDevice() {
+        return device;
+    }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof DriverData))
+            return false;
+
+        DriverData other = (DriverData) obj;
+        return compare(driver, other.getDriver())
+                && compare(instanceID, other.getInstanceID())
+                && compare(device, other.getDevice());
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = chainHashCode(super.hashCode(), this.driver);
+        hash = chainHashCode(hash, this.instanceID);
+        hash = chainHashCode(hash, this.device);
+        return hash;
+    }
 }

--- a/src/org/unbiquitous/uos/core/messageEngine/messages/Notify.java
+++ b/src/org/unbiquitous/uos/core/messageEngine/messages/Notify.java
@@ -86,7 +86,7 @@ public class Notify extends Message {
 		return this.addParameter(key, (Object) value);
 	}
 
-	private Notify addParameter(String key, Object value) {
+	public Notify addParameter(String key, Object value) {
 		if (parameters == null) {
 			parameters = new HashMap<String, Object>();
 		}

--- a/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
+++ b/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
@@ -1011,56 +1011,33 @@ public class DeviceManagerTest {
     @Test
     public void shouldNotThrowIfRemovingInvalidDeviceListener() throws Exception {
         deviceManager.removeDeviceListener(null);
-        deviceManager.removeDeviceListener(new DeviceListenerSwitch());
+        deviceManager.removeDeviceListener(mock(DeviceListener.class));
     }
 
     @Test
     public void shouldCallDeviceEnteredOnListenersIfRegisteredSuccessfully() throws Exception {
-        DeviceListenerSwitch listener = new DeviceListenerSwitch();
+        DeviceListener listener = mock(DeviceListener.class);
         deviceManager.addDeviceListener(listener);
         NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
         UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
                 .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
         when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
         deviceManager.deviceEntered(enteree);
-        assertEquals(1, listener.getEnteredCount(newGuy));
+        verify(listener, times(1)).deviceRegistered(newGuy);
     }
 
     @Test
     public void shouldCallDeviceLeftOnListenersIfKnownDeviceLeft() throws Exception {
-        DeviceListenerSwitch listener = new DeviceListenerSwitch();
+        DeviceListener listener = mock(DeviceListener.class);
         deviceManager.addDeviceListener(listener);
         NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
         UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
                 .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
         when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
         deviceManager.deviceEntered(enteree);
-        assertEquals(1, listener.getEnteredCount(newGuy));
+        verify(listener, times(1)).deviceRegistered(newGuy);
         deviceManager.deviceLeft(enteree);
-        assertEquals(1, listener.getEnteredCount(newGuy));
-        assertEquals(1, listener.getLeftCount(newGuy));
-    }
-
-    private static class DeviceListenerSwitch implements DeviceListener {
-        private Map<UpDevice, Integer> enteredDevices = new HashMap<UpDevice, Integer>();
-        private Map<UpDevice, Integer> leftDevices = new HashMap<UpDevice, Integer>();
-
-        @Override
-        public void deviceRegistered(UpDevice device) {
-            enteredDevices.put(device, getEnteredCount(device) + 1);
-        }
-
-        @Override
-        public void deviceUnregistered(UpDevice device) {
-            leftDevices.put(device, getLeftCount(device) + 1);
-        }
-
-        public int getEnteredCount(UpDevice device) {
-            return enteredDevices.containsKey(device) ? enteredDevices.get(device) : 0;
-        }
-
-        public int getLeftCount(UpDevice device) {
-            return leftDevices.containsKey(device) ? leftDevices.get(device) : 0;
-        }
+        verify(listener, times(1)).deviceUnregistered(newGuy);
+        verify(listener, times(1)).deviceRegistered(newGuy);
     }
 }

--- a/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
+++ b/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,952 +54,1013 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class DeviceManagerTest {
 
-	private final JsonNodeFactory factory = JsonNodeFactory.instance;
-	private final ObjectMapper mapper = new ObjectMapper();
-
-	private DeviceDao dao;
-	private DeviceManager deviceManager;
-	private DriverManager driverManager;
-	private UpDevice currentDevice;
-	private DriverDao driverDao;
-	private ConnectionManagerControlCenter connManager;
-	private Gateway gateway;
-	private ConnectivityManager proxier;
-
-	@Before
-	@SuppressWarnings("rawtypes")
-	public void setUp() {
-		dao = new DeviceDao(null);
-		driverDao = new DriverDao(null);
-		connManager = mock(ConnectionManagerControlCenter.class);
-		when(connManager.getHost(anyString())).thenAnswer(new Answer() {
-			@Override
-			public String answer(InvocationOnMock invocation) throws Throwable {
-				return (String) invocation.getArguments()[0];
-			}
-		});
-		gateway = mock(Gateway.class);
-		proxier = mock(ConnectivityManager.class);
-		currentDevice = new UpDevice("myDevice").addNetworkInterface("127.0.0.1:80", "Ethernet:TCP");
-		driverManager = new DriverManager(currentDevice, driverDao, dao, new ReflectionServiceCaller(null));
-		deviceManager = new DeviceManager(currentDevice, dao, driverDao, connManager, proxier, gateway, driverManager);
-	}
-
-	@After
-	public void tearDown() {
-		((DeviceDao) dao).clear();
-		driverDao.clear();
-	}
-
-	// public DeviceManager( UpDevice currentDevice,
-	// ConnectionManagerControlCenter connectionManagerControlCenter,
-	// ConnectivityManager connectivityManager, ResourceBundle resourceBundle,
-	// Gateway gateway) {
-	@Test
-	public void shouldSaveCurrentDeviceOnStart() {
-		List<UpDevice> devices = dao.list(null, null);
-		assertNotNull(devices);
-		assertEquals(1, devices.size());
-		assertEquals(currentDevice, devices.get(0));
-	}
-
-	// public void registerDevice(UpDevice device){
-	@Test
-	public void shouldSaveWhenRegistering() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		List<UpDevice> devices = dao.list(null, null);
-		assertNotNull(devices);
-		assertEquals(2, devices.size());
-		assertTrue(devices.contains(toRegister));
-	}
-
-	// public UpDevice retrieveDevice(String deviceName){
-	@Test
-	public void shouldRetrieveRegisteredDevice() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNotNull(deviceManager.retrieveDevice("aDevice"));
-		assertEquals(toRegister, deviceManager.retrieveDevice("aDevice"));
-	}
-
-	@Test
-	public void shouldNotRetrieveAUnRegisteredDevice() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNull(deviceManager.retrieveDevice("NotDevice"));
-	}
-
-	// public UpDevice retrieveDevice(String networkAdrress, String
-	// networkType){
-	@Test
-	public void shouldRetrieveARegisteredDeviceByNetworkAddress() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNotNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
-		assertEquals(toRegister, deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
-	}
-
-	@Test
-	public void shouldNotRetrieveAUnRegisteredDeviceByNetworkAddress() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNull(deviceManager.retrieveDevice("127.0.0.3", "Ethernet:TCP"));
-		assertNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:UDP"));
-	}
-
-	@Test
-	public void listsAllRegisteredDevices() {
-		UpDevice first = new UpDevice("firstDevice").addNetworkInterface("127.0.0.1", "Ethernet:TCP");
-		deviceManager.registerDevice(first);
-		UpDevice second = new UpDevice("secondDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(second);
-		assertThat(deviceManager.listDevices()).containsOnly(currentDevice, first, second);
-	}
-
-	// TODO: two devices with the same name == trouble
-
-	@Test
-	public void shouldRetrieveMultipleInstancesByDriverName() throws DriverManagerException, DriverNotFoundException {
-		UpDriver driver = new UpDriver("d1");
-		UpDevice myPhone = new UpDevice("my.Phone");
-		deviceManager.registerDevice(myPhone);
-		driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
-		driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		driverManager.insert(new DriverModel("id3", new UpDriver("d3"), "my.tablet"));
-		List<DriverData> list = driverManager.listDrivers("d1", null);
-		assertNotNull(list);
-		assertEquals(2, list.size());
-		assertEquals("id1", list.get(0).getInstanceID());
-		assertEquals(myPhone, list.get(0).getDevice());
-		assertEquals("id2", list.get(1).getInstanceID());
-		assertEquals(currentDevice, list.get(1).getDevice());
-	}
-
-	@Test
-	public void shouldRetrieveMultipleInstancesByDeviceName() throws DriverManagerException, DriverNotFoundException {
-		UpDriver driver = new UpDriver("d1");
-		driver.addService("s1").addParameter("p1", ParameterType.MANDATORY);
-		UpDriver driverD3 = new UpDriver("d3");
-		driverD3.addEvent("e1");
-		UpDevice myPhone = new UpDevice("my.Phone");
-		deviceManager.registerDevice(myPhone);
-		driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
-		driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		driverManager.insert(new DriverModel("id3", driverD3, "my.Phone"));
-		List<DriverData> list = driverManager.listDrivers(null, "my.Phone");
-		assertNotNull(list);
-		assertEquals(2, list.size());
-		assertEquals("id1", list.get(0).getInstanceID());
-		assertEquals(myPhone, list.get(0).getDevice());
-		assertEquals(driver, list.get(0).getDriver());
-		assertEquals("id3", list.get(1).getInstanceID());
-		assertEquals(myPhone, list.get(1).getDevice());
-		assertEquals(driverD3, list.get(1).getDriver());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceIsAlreadyKnownShouldDoNothing() throws Exception {
-		deviceManager.registerDevice(new UpDevice("IShouldKnow").addNetworkInterface("ADDR_KNOWN", "UNEXISTANT"));
-		assertEquals(2, dao.list().size());
-		when(connManager.getHost(eq("ADDR_KNOWN"))).thenReturn("ADDR_KNOWN");
-		NetworkDevice enteree = mock(NetworkDevice.class);
-		when(enteree.getNetworkDeviceName()).thenReturn("ADDR_KNOWN");
-		when(enteree.getNetworkDeviceType()).thenReturn("UNEXISTANT");
-		deviceManager.deviceEntered(enteree);
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(2, dao.list().size());
-	}
-
-	// null device or device data (addr and type)
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceIsNullShouldDoNothing() throws Exception {
-		assertEquals(1, dao.list().size());
-		deviceManager.deviceEntered(null);
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceProvidesNoDatalShouldDoNothing() throws Exception {
-		assertEquals(1, dao.list().size());
-		deviceManager.deviceEntered(mock(NetworkDevice.class));
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(1, dao.list().size());
-	}
-
-	// if doesn't knows the device, call 'handshake' on him passing
-	// currentDevice information
-	// Then register the device on the database
-
-	@Test
-	public void IfDontKnowTheDeviceCallAHandshakeWithIt() throws Exception {
-		when(gateway.callService((UpDevice) anyObject(), (Call) anyObject()))
-				.thenReturn(new Response().addParameter("device", mapper.writeValueAsString(new UpDevice("The Guy"))));
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		deviceManager.deviceEntered(enteree);
-		ArgumentCaptor<Call> scCacther = ArgumentCaptor.forClass(Call.class);
-		verify(gateway, times(2)).callService(any(UpDevice.class), scCacther.capture());
-		Call parameter = scCacther.getAllValues().get(0);
-		assertEquals("handshake", parameter.getService());
-		assertEquals("uos.DeviceDriver", parameter.getDriver());
-		assertNull(parameter.getInstanceId());
-		assertNull(parameter.getSecurityType());
-		assertEquals(currentDevice.toString(), parameter.getParameter("device"));
-	}
-
-	@Test
-	public void IfTheHandShakeWorksRegisterTheReturnedDevice() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheHandShakeHappensTwiceDoNothing() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheSecondHandShakeSucceedsRegisterDevice() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		deviceManager.deviceEntered(enteree);
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_NoResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(null);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_NoData() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(new Response());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_ErrorOnResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		Response error = new Response();
-		error.setError("Just Kidding");
-		when(gatewayHandshakeCall()).thenReturn(error);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_Exception() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenThrow(new RuntimeException());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	// if doesn't knows the device, call 'listDrivers'
-	// Then register the driver instances on the database
-
-	@Test
-	public void IfDontKnowTheDeviceCallListDriversOnIt() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		deviceManager.deviceEntered(enteree);
-		Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
-		verify(gateway, times(1)).callService(any(UpDevice.class), eq(listDrivers));
-	}
-
-	@Test
-	public void AfterListingTheDriverTheyMustBeRegistered() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
-				ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
-		deviceManager.deviceEntered(enteree);
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(2, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-		assertEquals("id2", newGuyDrivers.get(1).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToInterfaceValidationError() throws ServiceCallException, IOException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-
-		equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		UpService service = new UpService(Pointer.MOVE_EVENT);
-		service.addParameter(Pointer.AXIS_X, ParameterType.MANDATORY);
-		service.addParameter(Pointer.AXIS_Y, ParameterType.MANDATORY);
-		equivalentDriver.addEvent(service);
-
-		UpService register = new UpService("registerListener").addParameter("eventKey", ParameterType.MANDATORY);
-		equivalentDriver.addService(register);
-
-		UpService unregister = new UpService("unregisterListener").addParameter("eventKey", ParameterType.OPTIONAL);
-		equivalentDriver.addService(unregister);
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToNullEquivalentDriverResponse() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		when(gatewayTellEquivalentDriverCall()).thenReturn(null);
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToInterfaceNotProvided() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		when(gatewayTellEquivalentDriverCall()).thenReturn(new Response().addParameter("interfaces", null));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToWrongJSONObject() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		when(gatewayListDriversCall())
-				.thenReturn(new Response().addParameter("driverList", new String("wrongJSONObject")));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToMissingServer() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToEquivalentDriverInterfaceValidationError() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverWithEquivalentDriverNotInformed() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-		equivalentDriver.addEquivalentDrivers("notInformedEquivalentDriver");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	public void shouldNotRegisterADriverWithTwoEquivalentDriversNotInformed() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver1");
-		dummy.addEquivalentDrivers("equivalentDriver2");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver1 = new UpDriver("equivalentDriver1");
-		equivalentDriver1.addService("s1");
-		equivalentDriver1.addEquivalentDrivers("notInformedEquivalentDriver1");
-		UpDriver equivalentDriver2 = new UpDriver("equivalentDriver2");
-		equivalentDriver2.addEquivalentDrivers("notInformedEquivalentDriver2");
-		equivalentDriver2.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver1));
-		jsonList.add(mapper.valueToTree(equivalentDriver2));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldRegisterADriverWithUnknownEquivalentDriver() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(1, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriver() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-
-		UpDriver dummy1 = new UpDriver("DummyDriver1");
-		dummy1.addService("s1");
-		dummy1.addEquivalentDrivers("equivalentDriver");
-
-		UpDriver dummy2 = new UpDriver("DummyDriver2");
-		dummy2.addService("s1");
-		dummy2.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("iddummy1", mapper.valueToTree(dummy1));
-		driverList.set("iddummy2", mapper.valueToTree(dummy2));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		assertEquals(2, newGuyDrivers.size());
-		assertEquals("iddummy1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
-		assertEquals("iddummy2", newGuyDrivers.get(1).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
-	}
-
-	@Test
-	public void shouldRegisterADriverWithTwoLevelsOfUnknownEquivalentDrivers() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-		equivalentDriver.addEquivalentDrivers("equivalentToTheEquivalentDriver");
-
-		UpDriver equivalentToTheEquivalentDriver = new UpDriver("equivalentToTheEquivalentDriver");
-		equivalentToTheEquivalentDriver.addService("s1");
-
-		ArrayNode equivalentDrivers = factory.arrayNode();
-		equivalentDrivers.add(mapper.valueToTree(equivalentDriver));
-		equivalentDrivers.add(mapper.valueToTree(equivalentToTheEquivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", equivalentDrivers.toString()));
-
-		deviceManager.deviceEntered(enteree);
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		// verify(gatewayTellEquivalentDriverCall(), times(2));
-		assertEquals(1, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriverFromDifferentLevels()
-			throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-
-		UpDriver dummy1 = new UpDriver("D1");
-		dummy1.addService("s1");
-		dummy1.addEquivalentDrivers("D0");
-
-		UpDriver dummy2 = new UpDriver("D4");
-		dummy2.addService("s1");
-		dummy2.addEquivalentDrivers("D3");
-
-		driverList.set("iddummy1", mapper.valueToTree(dummy1));
-		driverList.set("iddummy2", mapper.valueToTree(dummy2));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver d0 = new UpDriver("D0");
-		d0.addService("s1");
-
-		UpDriver d2 = new UpDriver("D2");
-		d2.addService("s1");
-		d2.addEquivalentDrivers(d0.getName());
-
-		UpDriver d3 = new UpDriver("D3");
-		d3.addService("s1");
-		d3.addEquivalentDrivers(d2.getName());
-
-		jsonList.add(mapper.valueToTree(d3));
-		jsonList.add(mapper.valueToTree(d0));
-		jsonList.add(mapper.valueToTree(d2));
-
-		when(gatewayTellTwoEquivalentDrivers())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		// TODO: This
-		assertEquals(2, newGuyDrivers.size());
-		if (newGuyDrivers.get(0).id().equals("iddummy1")) {
-			assertEquals("iddummy1", newGuyDrivers.get(0).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
-			assertEquals("iddummy2", newGuyDrivers.get(1).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
-		} else {
-			assertEquals("iddummy2", newGuyDrivers.get(0).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy2));
-			assertEquals("iddummy1", newGuyDrivers.get(1).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy1));
-		}
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_NoResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenReturn(null);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_NoData() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenReturn(new Response());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	// FIXME: [B&M] Sempre passa! Como testar caso de erro?!
-	@Test
-	public void shouldNotHandshakeWithItsSelf() throws NetworkException, ServiceCallException {
-		NetworkDevice enteree = mock(NetworkDevice.class);
-
-		when(enteree.getNetworkDeviceName()).thenReturn("127.0.0.1:8080");
-		when(enteree.getNetworkDeviceType()).thenReturn("Ethernet:TCP");
-		when(connManager.getHost("127.0.0.1:8080")).thenReturn("127.0.0.1");
-		when(connManager.getHost("127.0.0.1:80")).thenReturn("127.0.0.1");
-		deviceManager.deviceEntered(enteree);
-		verify(gateway, never()).callService((UpDevice) any(), (Call) any());
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_ThrowingException() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenThrow(new RuntimeException());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	private NetworkDevice networkDevice(String address, String type) {
-		NetworkDevice enteree = mock(NetworkDevice.class);
-		when(enteree.getNetworkDeviceName()).thenReturn(address);
-		when(enteree.getNetworkDeviceType()).thenReturn(type);
-		return enteree;
-	}
-
-	private Response gatewayHandshakeCall() throws ServiceCallException {
-		Call handshake = new Call("uos.DeviceDriver", "handshake", null);
-		handshake.addParameter("device", currentDevice.toString());
-		return gateway.callService(any(UpDevice.class), eq(handshake));
-	}
-
-	private Response gatewayListDriversCall() throws ServiceCallException {
-		Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
-		return gateway.callService(any(UpDevice.class), eq(listDrivers));
-	}
-
-	private Response gatewayTellEquivalentDriverCall() throws ServiceCallException {
-		Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
-		ArrayNode equivalents = factory.arrayNode();
-		equivalents.add(factory.textNode("equivalentDriver"));
-		tellEquivalentDriver.addParameter("driversName", equivalents.toString());
-		return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
-	}
-
-	private Response gatewayTellTwoEquivalentDrivers() throws ServiceCallException {
-		Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
-		ArrayNode equivalents = factory.arrayNode();
-		equivalents.add(factory.textNode("D0"));
-		equivalents.add(factory.textNode("D3"));
-		tellEquivalentDriver.addParameter("driversName", equivalents.toString());
-		return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
-	}
-
-	// TODO: What about proxying
-	@Test
-	public void AfterListingIfProxyingIsEnabledRegisterIt() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response()
-					.addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString())
-		);
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1")
-			.addParameter("s1p1", ParameterType.MANDATORY)
-			.addParameter("s1p2", ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-		when(proxier.doProxying()).thenReturn(true);
-		deviceManager.deviceEntered(enteree);
-		ArgumentCaptor<UpDevice> deviceCatcher = ArgumentCaptor.forClass(UpDevice.class);
-		ArgumentCaptor<String> idCatcher = ArgumentCaptor.forClass(String.class);
-		verify(proxier, times(2)).registerProxyDriver(eq(dummy), deviceCatcher.capture(), idCatcher.capture());
-		assertEquals("A", deviceCatcher.getValue().getName());
-		assertEquals("id1", idCatcher.getAllValues().get(0));
-		assertEquals("id2", idCatcher.getAllValues().get(1));
-	}
-
-	@Test
-	public void AfterListingIfProxyingIsNotEnabledDoNothing() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
-				ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-		when(proxier.doProxying()).thenReturn(false);
-		deviceManager.deviceEntered(enteree);
-		verify(proxier, never()).registerProxyDriver(any(UpDriver.class), any(UpDevice.class), any(String.class));
-	}
-
-	// public void deviceLeft(NetworkDevice device) {
-	@Test
-	public void removeTheDeviceFromDatabaseOnLeft() throws Exception {
-		NetworkDevice leavingCard = networkDevice("ADDR_UNKNOWN_A", "UNEXISTANT");
-		UpDevice leavingGuy = upDevice("leavingMan", leavingCard);
-		when(connManager.getHost(eq(leavingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_A");
-		deviceManager.registerDevice(leavingGuy);
-
-		NetworkDevice stayingCard = networkDevice("ADDR_UNKNOWN_B", "UNEXISTANT");
-		UpDevice stayingGuy = upDevice("stayingMan", stayingCard);
-		when(connManager.getHost(eq(stayingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_B");
-		deviceManager.registerDevice(stayingGuy);
-
-		assertEquals(3, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id4", driver, stayingGuy.getName()));
-		assertEquals(4, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingCard);
-		assertEquals(2, dao.list().size());
-		assertEquals(1, driverDao.list().size());
-	}
-
-	private UpDevice upDevice(String name, NetworkDevice networkCard) {
-		return new UpDevice(name).addNetworkInterface(networkCard.getNetworkDeviceName(),
-				networkCard.getNetworkDeviceType());
-	}
-
-	@Test
-	public void doNothingWhenLeftingANullDevice() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice oldGuy = upDevice("OldMan", leavingGuy);
-		when(connManager.getHost(eq(leavingGuy.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN");
-		deviceManager.registerDevice(oldGuy);
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
-		assertEquals(3, driverDao.list().size());
-
-		deviceManager.deviceLeft(null);
-		assertEquals(2, dao.list().size());
-		assertEquals(3, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingADeviceWithNullData() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice oldGuy = upDevice("OldMan", leavingGuy);
-		deviceManager.registerDevice(oldGuy);
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
-		assertEquals(3, driverDao.list().size());
-
-		deviceManager.deviceLeft(mock(NetworkDevice.class));
-		assertEquals(2, dao.list().size());
-		assertEquals(3, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingAnUnkownDevice() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		assertEquals(1, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
-		driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		assertEquals(2, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingGuy);
-		assertEquals(1, dao.list().size());
-		assertEquals(2, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingAnUnkownDevicexxxx() throws Exception {
-		NetworkDevice knownCard = networkDevice("ADDR_KNOWN", "THIS_ONE");
-		UpDevice knownGuy = upDevice("OldMan", knownCard);
-		deviceManager.registerDevice(knownGuy);
-
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "THIS_ONE");
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
-		driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		assertEquals(2, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingGuy);
-		assertEquals(2, dao.list().size());
-		assertEquals(2, driverDao.list().size());
-	}
+    private final JsonNodeFactory factory = JsonNodeFactory.instance;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private DeviceDao dao;
+    private DeviceManager deviceManager;
+    private DriverManager driverManager;
+    private UpDevice currentDevice;
+    private DriverDao driverDao;
+    private ConnectionManagerControlCenter connManager;
+    private Gateway gateway;
+    private ConnectivityManager proxier;
+
+    @Before
+    @SuppressWarnings("rawtypes")
+    public void setUp() {
+        dao = new DeviceDao(null);
+        driverDao = new DriverDao(null);
+        connManager = mock(ConnectionManagerControlCenter.class);
+        when(connManager.getHost(anyString())).thenAnswer(new Answer() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return (String) invocation.getArguments()[0];
+            }
+        });
+        gateway = mock(Gateway.class);
+        proxier = mock(ConnectivityManager.class);
+        currentDevice = new UpDevice("myDevice").addNetworkInterface("127.0.0.1:80", "Ethernet:TCP");
+        driverManager = new DriverManager(currentDevice, driverDao, dao, new ReflectionServiceCaller(null));
+        deviceManager = new DeviceManager(currentDevice, dao, driverDao, connManager, proxier, gateway, driverManager);
+    }
+
+    @After
+    public void tearDown() {
+        ((DeviceDao) dao).clear();
+        driverDao.clear();
+    }
+
+    // public DeviceManager( UpDevice currentDevice,
+    // ConnectionManagerControlCenter connectionManagerControlCenter,
+    // ConnectivityManager connectivityManager, ResourceBundle resourceBundle,
+    // Gateway gateway) {
+    @Test
+    public void shouldSaveCurrentDeviceOnStart() {
+        List<UpDevice> devices = dao.list(null, null);
+        assertNotNull(devices);
+        assertEquals(1, devices.size());
+        assertEquals(currentDevice, devices.get(0));
+    }
+
+    // public void registerDevice(UpDevice device){
+    @Test
+    public void shouldSaveWhenRegistering() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        List<UpDevice> devices = dao.list(null, null);
+        assertNotNull(devices);
+        assertEquals(2, devices.size());
+        assertTrue(devices.contains(toRegister));
+    }
+
+    // public UpDevice retrieveDevice(String deviceName){
+    @Test
+    public void shouldRetrieveRegisteredDevice() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNotNull(deviceManager.retrieveDevice("aDevice"));
+        assertEquals(toRegister, deviceManager.retrieveDevice("aDevice"));
+    }
+
+    @Test
+    public void shouldNotRetrieveAUnRegisteredDevice() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNull(deviceManager.retrieveDevice("NotDevice"));
+    }
+
+    // public UpDevice retrieveDevice(String networkAdrress, String
+    // networkType){
+    @Test
+    public void shouldRetrieveARegisteredDeviceByNetworkAddress() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNotNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
+        assertEquals(toRegister, deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
+    }
+
+    @Test
+    public void shouldNotRetrieveAUnRegisteredDeviceByNetworkAddress() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNull(deviceManager.retrieveDevice("127.0.0.3", "Ethernet:TCP"));
+        assertNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:UDP"));
+    }
+
+    @Test
+    public void listsAllRegisteredDevices() {
+        UpDevice first = new UpDevice("firstDevice").addNetworkInterface("127.0.0.1", "Ethernet:TCP");
+        deviceManager.registerDevice(first);
+        UpDevice second = new UpDevice("secondDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(second);
+        assertThat(deviceManager.listDevices()).containsOnly(currentDevice, first, second);
+    }
+
+    // TODO: two devices with the same name == trouble
+
+    @Test
+    public void shouldRetrieveMultipleInstancesByDriverName() throws DriverManagerException, DriverNotFoundException {
+        UpDriver driver = new UpDriver("d1");
+        UpDevice myPhone = new UpDevice("my.Phone");
+        deviceManager.registerDevice(myPhone);
+        driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
+        driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        driverManager.insert(new DriverModel("id3", new UpDriver("d3"), "my.tablet"));
+        List<DriverData> list = driverManager.listDrivers("d1", null);
+        assertNotNull(list);
+        assertEquals(2, list.size());
+        assertEquals("id1", list.get(0).getInstanceID());
+        assertEquals(myPhone, list.get(0).getDevice());
+        assertEquals("id2", list.get(1).getInstanceID());
+        assertEquals(currentDevice, list.get(1).getDevice());
+    }
+
+    @Test
+    public void shouldRetrieveMultipleInstancesByDeviceName() throws DriverManagerException, DriverNotFoundException {
+        UpDriver driver = new UpDriver("d1");
+        driver.addService("s1").addParameter("p1", ParameterType.MANDATORY);
+        UpDriver driverD3 = new UpDriver("d3");
+        driverD3.addEvent("e1");
+        UpDevice myPhone = new UpDevice("my.Phone");
+        deviceManager.registerDevice(myPhone);
+        driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
+        driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        driverManager.insert(new DriverModel("id3", driverD3, "my.Phone"));
+        List<DriverData> list = driverManager.listDrivers(null, "my.Phone");
+        assertNotNull(list);
+        assertEquals(2, list.size());
+        assertEquals("id1", list.get(0).getInstanceID());
+        assertEquals(myPhone, list.get(0).getDevice());
+        assertEquals(driver, list.get(0).getDriver());
+        assertEquals("id3", list.get(1).getInstanceID());
+        assertEquals(myPhone, list.get(1).getDevice());
+        assertEquals(driverD3, list.get(1).getDriver());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceIsAlreadyKnownShouldDoNothing() throws Exception {
+        deviceManager.registerDevice(new UpDevice("IShouldKnow").addNetworkInterface("ADDR_KNOWN", "UNEXISTANT"));
+        assertEquals(2, dao.list().size());
+        when(connManager.getHost(eq("ADDR_KNOWN"))).thenReturn("ADDR_KNOWN");
+        NetworkDevice enteree = mock(NetworkDevice.class);
+        when(enteree.getNetworkDeviceName()).thenReturn("ADDR_KNOWN");
+        when(enteree.getNetworkDeviceType()).thenReturn("UNEXISTANT");
+        deviceManager.deviceEntered(enteree);
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(2, dao.list().size());
+    }
+
+    // null device or device data (addr and type)
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceIsNullShouldDoNothing() throws Exception {
+        assertEquals(1, dao.list().size());
+        deviceManager.deviceEntered(null);
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceProvidesNoDatalShouldDoNothing() throws Exception {
+        assertEquals(1, dao.list().size());
+        deviceManager.deviceEntered(mock(NetworkDevice.class));
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(1, dao.list().size());
+    }
+
+    // if doesn't knows the device, call 'handshake' on him passing
+    // currentDevice information
+    // Then register the device on the database
+
+    @Test
+    public void IfDontKnowTheDeviceCallAHandshakeWithIt() throws Exception {
+        when(gateway.callService((UpDevice) anyObject(), (Call) anyObject()))
+                .thenReturn(new Response().addParameter("device", mapper.writeValueAsString(new UpDevice("The Guy"))));
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        deviceManager.deviceEntered(enteree);
+        ArgumentCaptor<Call> scCacther = ArgumentCaptor.forClass(Call.class);
+        verify(gateway, times(2)).callService(any(UpDevice.class), scCacther.capture());
+        Call parameter = scCacther.getAllValues().get(0);
+        assertEquals("handshake", parameter.getService());
+        assertEquals("uos.DeviceDriver", parameter.getDriver());
+        assertNull(parameter.getInstanceId());
+        assertNull(parameter.getSecurityType());
+        assertEquals(currentDevice.toString(), parameter.getParameter("device"));
+    }
+
+    @Test
+    public void IfTheHandShakeWorksRegisterTheReturnedDevice() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheHandShakeHappensTwiceDoNothing() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheSecondHandShakeSucceedsRegisterDevice() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        deviceManager.deviceEntered(enteree);
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_NoResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(null);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_NoData() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(new Response());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_ErrorOnResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        Response error = new Response();
+        error.setError("Just Kidding");
+        when(gatewayHandshakeCall()).thenReturn(error);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_Exception() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenThrow(new RuntimeException());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    // if doesn't knows the device, call 'listDrivers'
+    // Then register the driver instances on the database
+
+    @Test
+    public void IfDontKnowTheDeviceCallListDriversOnIt() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        deviceManager.deviceEntered(enteree);
+        Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
+        verify(gateway, times(1)).callService(any(UpDevice.class), eq(listDrivers));
+    }
+
+    @Test
+    public void AfterListingTheDriverTheyMustBeRegistered() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
+                ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+        driverList.set("id2", mapper.valueToTree(dummy));
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
+        deviceManager.deviceEntered(enteree);
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(2, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
+        assertEquals("id2", newGuyDrivers.get(1).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy));
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToInterfaceValidationError() throws ServiceCallException, IOException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        ObjectNode driverList = factory.objectNode();
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+
+        equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        UpService service = new UpService(Pointer.MOVE_EVENT);
+        service.addParameter(Pointer.AXIS_X, ParameterType.MANDATORY);
+        service.addParameter(Pointer.AXIS_Y, ParameterType.MANDATORY);
+        equivalentDriver.addEvent(service);
+
+        UpService register = new UpService("registerListener").addParameter("eventKey", ParameterType.MANDATORY);
+        equivalentDriver.addService(register);
+
+        UpService unregister = new UpService("unregisterListener").addParameter("eventKey", ParameterType.OPTIONAL);
+        equivalentDriver.addService(unregister);
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToNullEquivalentDriverResponse() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        ObjectNode driverList = factory.objectNode();
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        when(gatewayTellEquivalentDriverCall()).thenReturn(null);
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToInterfaceNotProvided() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        ObjectNode driverList = factory.objectNode();
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        when(gatewayTellEquivalentDriverCall()).thenReturn(new Response().addParameter("interfaces", null));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToWrongJSONObject() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        when(gatewayListDriversCall())
+                .thenReturn(new Response().addParameter("driverList", new String("wrongJSONObject")));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToMissingServer() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToEquivalentDriverInterfaceValidationError() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
+        equivalentDriver.addService("s1");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverWithEquivalentDriverNotInformed() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+        equivalentDriver.addEquivalentDrivers("notInformedEquivalentDriver");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    public void shouldNotRegisterADriverWithTwoEquivalentDriversNotInformed() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver1");
+        dummy.addEquivalentDrivers("equivalentDriver2");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver1 = new UpDriver("equivalentDriver1");
+        equivalentDriver1.addService("s1");
+        equivalentDriver1.addEquivalentDrivers("notInformedEquivalentDriver1");
+        UpDriver equivalentDriver2 = new UpDriver("equivalentDriver2");
+        equivalentDriver2.addEquivalentDrivers("notInformedEquivalentDriver2");
+        equivalentDriver2.addService("s1");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver1));
+        jsonList.add(mapper.valueToTree(equivalentDriver2));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldRegisterADriverWithUnknownEquivalentDriver() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(1, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
+    }
+
+    @Test
+    public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriver() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+
+        UpDriver dummy1 = new UpDriver("DummyDriver1");
+        dummy1.addService("s1");
+        dummy1.addEquivalentDrivers("equivalentDriver");
+
+        UpDriver dummy2 = new UpDriver("DummyDriver2");
+        dummy2.addService("s1");
+        dummy2.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("iddummy1", mapper.valueToTree(dummy1));
+        driverList.set("iddummy2", mapper.valueToTree(dummy2));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        assertEquals(2, newGuyDrivers.size());
+        assertEquals("iddummy1", newGuyDrivers.get(0).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
+        assertEquals("iddummy2", newGuyDrivers.get(1).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
+    }
+
+    @Test
+    public void shouldRegisterADriverWithTwoLevelsOfUnknownEquivalentDrivers() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+        equivalentDriver.addEquivalentDrivers("equivalentToTheEquivalentDriver");
+
+        UpDriver equivalentToTheEquivalentDriver = new UpDriver("equivalentToTheEquivalentDriver");
+        equivalentToTheEquivalentDriver.addService("s1");
+
+        ArrayNode equivalentDrivers = factory.arrayNode();
+        equivalentDrivers.add(mapper.valueToTree(equivalentDriver));
+        equivalentDrivers.add(mapper.valueToTree(equivalentToTheEquivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", equivalentDrivers.toString()));
+
+        deviceManager.deviceEntered(enteree);
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        // verify(gatewayTellEquivalentDriverCall(), times(2));
+        assertEquals(1, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
+    }
+
+    @Test
+    public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriverFromDifferentLevels()
+            throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+
+        UpDriver dummy1 = new UpDriver("D1");
+        dummy1.addService("s1");
+        dummy1.addEquivalentDrivers("D0");
+
+        UpDriver dummy2 = new UpDriver("D4");
+        dummy2.addService("s1");
+        dummy2.addEquivalentDrivers("D3");
+
+        driverList.set("iddummy1", mapper.valueToTree(dummy1));
+        driverList.set("iddummy2", mapper.valueToTree(dummy2));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver d0 = new UpDriver("D0");
+        d0.addService("s1");
+
+        UpDriver d2 = new UpDriver("D2");
+        d2.addService("s1");
+        d2.addEquivalentDrivers(d0.getName());
+
+        UpDriver d3 = new UpDriver("D3");
+        d3.addService("s1");
+        d3.addEquivalentDrivers(d2.getName());
+
+        jsonList.add(mapper.valueToTree(d3));
+        jsonList.add(mapper.valueToTree(d0));
+        jsonList.add(mapper.valueToTree(d2));
+
+        when(gatewayTellTwoEquivalentDrivers())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        // TODO: This
+        assertEquals(2, newGuyDrivers.size());
+        if (newGuyDrivers.get(0).id().equals("iddummy1")) {
+            assertEquals("iddummy1", newGuyDrivers.get(0).id());
+            assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
+            assertEquals("iddummy2", newGuyDrivers.get(1).id());
+            assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
+        } else {
+            assertEquals("iddummy2", newGuyDrivers.get(0).id());
+            assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy2));
+            assertEquals("iddummy1", newGuyDrivers.get(1).id());
+            assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy1));
+        }
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_NoResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        when(gatewayListDriversCall()).thenReturn(null);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_NoData() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        when(gatewayListDriversCall()).thenReturn(new Response());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    // FIXME: [B&M] Sempre passa! Como testar caso de erro?!
+    @Test
+    public void shouldNotHandshakeWithItsSelf() throws NetworkException, ServiceCallException {
+        NetworkDevice enteree = mock(NetworkDevice.class);
+
+        when(enteree.getNetworkDeviceName()).thenReturn("127.0.0.1:8080");
+        when(enteree.getNetworkDeviceType()).thenReturn("Ethernet:TCP");
+        when(connManager.getHost("127.0.0.1:8080")).thenReturn("127.0.0.1");
+        when(connManager.getHost("127.0.0.1:80")).thenReturn("127.0.0.1");
+        deviceManager.deviceEntered(enteree);
+        verify(gateway, never()).callService((UpDevice) any(), (Call) any());
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_ThrowingException() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        when(gatewayListDriversCall()).thenThrow(new RuntimeException());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    private NetworkDevice networkDevice(String address, String type) {
+        NetworkDevice enteree = mock(NetworkDevice.class);
+        when(enteree.getNetworkDeviceName()).thenReturn(address);
+        when(enteree.getNetworkDeviceType()).thenReturn(type);
+        return enteree;
+    }
+
+    private Response gatewayHandshakeCall() throws ServiceCallException {
+        Call handshake = new Call("uos.DeviceDriver", "handshake", null);
+        handshake.addParameter("device", currentDevice.toString());
+        return gateway.callService(any(UpDevice.class), eq(handshake));
+    }
+
+    private Response gatewayListDriversCall() throws ServiceCallException {
+        Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
+        return gateway.callService(any(UpDevice.class), eq(listDrivers));
+    }
+
+    private Response gatewayTellEquivalentDriverCall() throws ServiceCallException {
+        Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
+        ArrayNode equivalents = factory.arrayNode();
+        equivalents.add(factory.textNode("equivalentDriver"));
+        tellEquivalentDriver.addParameter("driversName", equivalents.toString());
+        return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
+    }
+
+    private Response gatewayTellTwoEquivalentDrivers() throws ServiceCallException {
+        Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
+        ArrayNode equivalents = factory.arrayNode();
+        equivalents.add(factory.textNode("D0"));
+        equivalents.add(factory.textNode("D3"));
+        tellEquivalentDriver.addParameter("driversName", equivalents.toString());
+        return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
+    }
+
+    // TODO: What about proxying
+    @Test
+    public void AfterListingIfProxyingIsEnabledRegisterIt() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response()
+                        .addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString())
+        );
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1")
+                .addParameter("s1p1", ParameterType.MANDATORY)
+                .addParameter("s1p2", ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+        driverList.set("id2", mapper.valueToTree(dummy));
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+        when(proxier.doProxying()).thenReturn(true);
+        deviceManager.deviceEntered(enteree);
+        ArgumentCaptor<UpDevice> deviceCatcher = ArgumentCaptor.forClass(UpDevice.class);
+        ArgumentCaptor<String> idCatcher = ArgumentCaptor.forClass(String.class);
+        verify(proxier, times(2)).registerProxyDriver(eq(dummy), deviceCatcher.capture(), idCatcher.capture());
+        assertEquals("A", deviceCatcher.getValue().getName());
+        assertEquals("id1", idCatcher.getAllValues().get(0));
+        assertEquals("id2", idCatcher.getAllValues().get(1));
+    }
+
+    @Test
+    public void AfterListingIfProxyingIsNotEnabledDoNothing() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
+                ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+        driverList.set("id2", mapper.valueToTree(dummy));
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+        when(proxier.doProxying()).thenReturn(false);
+        deviceManager.deviceEntered(enteree);
+        verify(proxier, never()).registerProxyDriver(any(UpDriver.class), any(UpDevice.class), any(String.class));
+    }
+
+    // public void deviceLeft(NetworkDevice device) {
+    @Test
+    public void removeTheDeviceFromDatabaseOnLeft() throws Exception {
+        NetworkDevice leavingCard = networkDevice("ADDR_UNKNOWN_A", "UNEXISTANT");
+        UpDevice leavingGuy = upDevice("leavingMan", leavingCard);
+        when(connManager.getHost(eq(leavingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_A");
+        deviceManager.registerDevice(leavingGuy);
+
+        NetworkDevice stayingCard = networkDevice("ADDR_UNKNOWN_B", "UNEXISTANT");
+        UpDevice stayingGuy = upDevice("stayingMan", stayingCard);
+        when(connManager.getHost(eq(stayingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_B");
+        deviceManager.registerDevice(stayingGuy);
+
+        assertEquals(3, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id4", driver, stayingGuy.getName()));
+        assertEquals(4, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingCard);
+        assertEquals(2, dao.list().size());
+        assertEquals(1, driverDao.list().size());
+    }
+
+    private UpDevice upDevice(String name, NetworkDevice networkCard) {
+        return new UpDevice(name).addNetworkInterface(networkCard.getNetworkDeviceName(),
+                networkCard.getNetworkDeviceType());
+    }
+
+    @Test
+    public void doNothingWhenLeftingANullDevice() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice oldGuy = upDevice("OldMan", leavingGuy);
+        when(connManager.getHost(eq(leavingGuy.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN");
+        deviceManager.registerDevice(oldGuy);
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
+        assertEquals(3, driverDao.list().size());
+
+        deviceManager.deviceLeft(null);
+        assertEquals(2, dao.list().size());
+        assertEquals(3, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingADeviceWithNullData() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice oldGuy = upDevice("OldMan", leavingGuy);
+        deviceManager.registerDevice(oldGuy);
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
+        assertEquals(3, driverDao.list().size());
+
+        deviceManager.deviceLeft(mock(NetworkDevice.class));
+        assertEquals(2, dao.list().size());
+        assertEquals(3, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingAnUnkownDevice() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        assertEquals(1, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
+        driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        assertEquals(2, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingGuy);
+        assertEquals(1, dao.list().size());
+        assertEquals(2, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingAnUnkownDevicexxxx() throws Exception {
+        NetworkDevice knownCard = networkDevice("ADDR_KNOWN", "THIS_ONE");
+        UpDevice knownGuy = upDevice("OldMan", knownCard);
+        deviceManager.registerDevice(knownGuy);
+
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "THIS_ONE");
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
+        driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        assertEquals(2, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingGuy);
+        assertEquals(2, dao.list().size());
+        assertEquals(2, driverDao.list().size());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowIfAddingNullDeviceListener() throws Exception {
+        deviceManager.addDeviceListener(null);
+    }
+
+    @Test
+    public void shouldNotThrowIfRemovingInvalidDeviceListener() throws Exception {
+        deviceManager.removeDeviceListener(null);
+        deviceManager.removeDeviceListener(new DeviceListenerSwitch());
+    }
+
+    @Test
+    public void shouldCallDeviceEnteredOnListenersIfRegisteredSuccessfully() throws Exception {
+        DeviceListenerSwitch listener = new DeviceListenerSwitch();
+        deviceManager.addDeviceListener(listener);
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, listener.getEnteredCount(newGuy));
+    }
+
+    @Test
+    public void shouldCallDeviceLeftOnListenersIfKnownDeviceLeft() throws Exception {
+        DeviceListenerSwitch listener = new DeviceListenerSwitch();
+        deviceManager.addDeviceListener(listener);
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, listener.getEnteredCount(newGuy));
+        deviceManager.deviceLeft(enteree);
+        assertEquals(1, listener.getEnteredCount(newGuy));
+        assertEquals(1, listener.getLeftCount(newGuy));
+    }
+
+    private static class DeviceListenerSwitch implements DeviceListener {
+        private Map<UpDevice, Integer> enteredDevices = new HashMap<UpDevice, Integer>();
+        private Map<UpDevice, Integer> leftDevices = new HashMap<UpDevice, Integer>();
+
+        @Override
+        public void deviceRegistered(UpDevice device) {
+            enteredDevices.put(device, getEnteredCount(device) + 1);
+        }
+
+        @Override
+        public void deviceUnregistered(UpDevice device) {
+            leftDevices.put(device, getLeftCount(device) + 1);
+        }
+
+        public int getEnteredCount(UpDevice device) {
+            return enteredDevices.containsKey(device) ? enteredDevices.get(device) : 0;
+        }
+
+        public int getLeftCount(UpDevice device) {
+            return leftDevices.containsKey(device) ? leftDevices.get(device) : 0;
+        }
+    }
 }


### PR DESCRIPTION
For ClassLoaderUitls, the old implementation returns the system class loader as root class loader. On some dalvik runtimes, this loader references a nonexistent path for a unknown reason. This new implementation works on all supported platforms and is more elegant, since it returns the whole known hierarchy of class loaders, instead of just the system root.

For DeviceManager, included capacity to notify interested listeners when devices enter and leave smartspace. Also, for DeviceManager and DeviceDriver, a more (jackson/json) transparent implementation, handling "objects as JSON strings" and "objects as JSON objects" cases elegantly. This modification also prevents data from traveling in the "JSON objects as strings" formats and serialiases/deserialises all basic objects to/from JSON directly.
