### PR TITLE
ClassLoaderUtils retrieves a default class loader in a more portable way

### DIFF
--- a/src/org/unbiquitous/uos/core/ClassLoaderUtils.java
+++ b/src/org/unbiquitous/uos/core/ClassLoaderUtils.java
@@ -23,7 +23,7 @@ public class ClassLoaderUtils {
 
 		@Override
 		public ClassLoader getParentClassLoader() {
-			return ClassLoader.getSystemClassLoader();
+			return this.getClass().getClassLoader();
 		}
 	}
 


### PR DESCRIPTION
The previous implementation returns the system class loader as root class loader. On some dalvik runtimes, this loader references a nonexistent path. This new implementation works on all supported platforms and is more reliable, since it returns the whole known hierarchy of class loaders, instead of just the system root.
