### PR TITLE
Improvements on DeviceManager and DeviceDriver

### DIFF
--- a/src/org/unbiquitous/uos/core/ClassLoaderUtils.java
+++ b/src/org/unbiquitous/uos/core/ClassLoaderUtils.java
@@ -23,7 +23,7 @@ public class ClassLoaderUtils {
 
 		@Override
 		public ClassLoader getParentClassLoader() {
-			return ClassLoader.getSystemClassLoader();
+			return this.getClass().getClassLoader();
 		}
 	}
 

--- a/src/org/unbiquitous/uos/core/deviceManager/DeviceListener.java
+++ b/src/org/unbiquitous/uos/core/deviceManager/DeviceListener.java
@@ -1,0 +1,25 @@
+package org.unbiquitous.uos.core.deviceManager;
+
+import org.unbiquitous.uos.core.messageEngine.dataType.UpDevice;
+
+/**
+ * Interested listeners must implement this interface to be notified by the device manager of device registration
+ * related events.
+ *
+ * @author Luciano Santos
+ */
+public interface DeviceListener {
+    /**
+     * Called when a device is successfully registered in the device manager.
+     *
+     * @param device A reference to the device has just entered the smart-space.
+     */
+    void deviceRegistered(UpDevice device);
+
+    /**
+     * Called when a previously knwon device is unregistered in the device manager.
+     *
+     * @param device A reference to the device has just left the smart-space.
+     */
+    void deviceUnregistered(UpDevice device);
+}

--- a/src/org/unbiquitous/uos/core/deviceManager/DeviceManager.java
+++ b/src/org/unbiquitous/uos/core/deviceManager/DeviceManager.java
@@ -1,25 +1,12 @@
 package org.unbiquitous.uos.core.deviceManager;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.unbiquitous.uos.core.UOSLogging;
 import org.unbiquitous.uos.core.adaptabitilyEngine.Gateway;
 import org.unbiquitous.uos.core.adaptabitilyEngine.ServiceCallException;
 import org.unbiquitous.uos.core.connectivity.ConnectivityManager;
-import org.unbiquitous.uos.core.driverManager.DriverDao;
-import org.unbiquitous.uos.core.driverManager.DriverManager;
-import org.unbiquitous.uos.core.driverManager.DriverManagerException;
-import org.unbiquitous.uos.core.driverManager.DriverModel;
-import org.unbiquitous.uos.core.driverManager.DriverNotFoundException;
-import org.unbiquitous.uos.core.driverManager.InterfaceValidationException;
+import org.unbiquitous.uos.core.driverManager.*;
 import org.unbiquitous.uos.core.messageEngine.dataType.UpDevice;
 import org.unbiquitous.uos.core.messageEngine.dataType.UpDriver;
 import org.unbiquitous.uos.core.messageEngine.dataType.UpNetworkInterface;
@@ -29,339 +16,350 @@ import org.unbiquitous.uos.core.network.connectionManager.ConnectionManagerContr
 import org.unbiquitous.uos.core.network.model.NetworkDevice;
 import org.unbiquitous.uos.core.network.radar.RadarListener;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Class responsible for managing the devices in the neighborhood of the current
  * device.
- * 
+ *
  * @author Fabricio Nogueira Buzeto
- * 
  */
 public class DeviceManager implements RadarListener {
 
-	private static final String DEVICE_DRIVER_NAME = "uos.DeviceDriver";
+    private static final String DEVICE_DRIVER_NAME = "uos.DeviceDriver";
 
-	private static final String DRIVERS_NAME_KEY = "driversName";
+    private static final String DRIVERS_NAME_KEY = "driversName";
 
-	private static final String INTERFACES_KEY = "interfaces";
+    private static final String INTERFACES_KEY = "interfaces";
 
-	private static final Logger logger = UOSLogging.getLogger();
-	private static final ObjectMapper mapper = new ObjectMapper();
+    private static final Logger logger = UOSLogging.getLogger();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-	private Gateway gateway;
+    private Gateway gateway;
 
-	private ConnectionManagerControlCenter connectionManagerControlCenter;
+    private ConnectionManagerControlCenter connectionManagerControlCenter;
 
-	private DeviceDao deviceDao;
+    private DeviceDao deviceDao;
 
-	private UpDevice currentDevice;
+    private UpDevice currentDevice;
 
-	private ConnectivityManager connectivityManager;
+    private ConnectivityManager connectivityManager;
 
-	private DriverManager driverManager;
+    private DriverManager driverManager;
 
-	private Set<String> unknownDrivers;
+    private Set<String> unknownDrivers;
 
-	private Set<DriverModel> dependents;
+    private Set<DriverModel> dependents;
 
-	public DeviceManager(UpDevice currentDevice, DeviceDao deviceDao, DriverDao driverDao,
-			ConnectionManagerControlCenter connectionManagerControlCenter, ConnectivityManager connectivityManager,
-			Gateway gateway, DriverManager driverManager) {
-		this.gateway = gateway;
-		this.connectionManagerControlCenter = connectionManagerControlCenter;
-		this.currentDevice = currentDevice;
-		this.connectivityManager = connectivityManager;
-		this.deviceDao = deviceDao;
-		this.deviceDao.save(currentDevice);
-		this.driverManager = driverManager;
-		this.unknownDrivers = new HashSet<String>();
-		this.dependents = new HashSet<DriverModel>();
-	}
+    private Set<DeviceListener> deviceListeners;
 
-	/**
-	 * Method responsible for registering a device in the neighborhood of the
-	 * current device.
-	 * 
-	 * @param device
-	 *            Device to be registered.
-	 */
-	public void registerDevice(UpDevice device) {
-		deviceDao.save(device);
-	}
+    public DeviceManager(UpDevice currentDevice, DeviceDao deviceDao, DriverDao driverDao,
+                         ConnectionManagerControlCenter connectionManagerControlCenter, ConnectivityManager connectivityManager,
+                         Gateway gateway, DriverManager driverManager) {
+        this.gateway = gateway;
+        this.connectionManagerControlCenter = connectionManagerControlCenter;
+        this.currentDevice = currentDevice;
+        this.connectivityManager = connectivityManager;
+        this.deviceDao = deviceDao;
+        this.deviceDao.save(currentDevice);
+        this.driverManager = driverManager;
+        this.unknownDrivers = new HashSet<String>();
+        this.dependents = new HashSet<DriverModel>();
+        this.deviceListeners = new HashSet<DeviceListener>();
+    }
 
-	/**
-	 * Method responsible for finding the data about a device present in the
-	 * neighborhood.
-	 * 
-	 * @param deviceName
-	 *            Device name to be found.
-	 * @return <code>UpDevice</code> with the data about the informed device.
-	 */
-	public UpDevice retrieveDevice(String deviceName) {
-		return deviceDao.find(deviceName);
-	}
+    /**
+     * Method responsible for registering a device in the neighborhood of the
+     * current device.
+     *
+     * @param device Device to be registered.
+     */
+    public void registerDevice(UpDevice device) {
+        deviceDao.save(device);
+    }
 
-	/**
-	 * Method responsible for finding the data about a device present in the
-	 * neighborhood.
-	 * 
-	 * @param networkAddress
-	 *            Address of the Device to be found.
-	 * @param networkType
-	 *            NetworkType of Address of the Device to be found.
-	 * @return <code>UpDevice</code> with the data about the informed device.
-	 */
-	public UpDevice retrieveDevice(String networkAddress, String networkType) {
-		List<UpDevice> list = deviceDao.list(networkAddress, networkType);
-		if (list != null && !list.isEmpty()) {
-			UpDevice deviceFound = list.get(0);
-			logger.fine("Device with addr '" + networkAddress + "' found on network '" + networkType + "' resolved to "
-					+ deviceFound);
-			return deviceFound;
-		}
-		logger.fine("No device found with addr '" + networkAddress + "' on network '" + networkType + "'.");
-		return null;
-	}
+    /**
+     * Method responsible for finding the data about a device present in the
+     * neighborhood.
+     *
+     * @param deviceName Device name to be found.
+     * @return <code>UpDevice</code> with the data about the informed device.
+     */
+    public UpDevice retrieveDevice(String deviceName) {
+        return deviceDao.find(deviceName);
+    }
 
-	/**
-	 * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceEntered(org.unbiquitous.uos.core.network.model.NetworkDevice)
-	 */
-	@Override
-	public void deviceEntered(NetworkDevice device) {
-		if (device == null)
-			return;
+    /**
+     * Method responsible for finding the data about a device present in the
+     * neighborhood.
+     *
+     * @param networkAddress Address of the Device to be found.
+     * @param networkType    NetworkType of Address of the Device to be found.
+     * @return <code>UpDevice</code> with the data about the informed device.
+     */
+    public UpDevice retrieveDevice(String networkAddress, String networkType) {
+        List<UpDevice> list = deviceDao.list(networkAddress, networkType);
+        if (list != null && !list.isEmpty()) {
+            UpDevice deviceFound = list.get(0);
+            logger.fine("Device with addr '" + networkAddress + "' found on network '" + networkType + "' resolved to "
+                    + deviceFound);
+            return deviceFound;
+        }
+        logger.fine("No device found with addr '" + networkAddress + "' on network '" + networkType + "'.");
+        return null;
+    }
 
-		// verify if device entered is the current device
-		String deviceHost = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
-		for (UpNetworkInterface networkInterface : this.currentDevice.getNetworks()) {
-			String currentDeviceHost = connectionManagerControlCenter.getHost(networkInterface.getNetworkAddress());
-			if (deviceHost != null && deviceHost.equals(currentDeviceHost)) {
-				logger.fine("Host of device entered is the same of current device:" + device.getNetworkDeviceName());
-				return;
-			}
-		}
+    /**
+     * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceEntered(org.unbiquitous.uos.core.network.model.NetworkDevice)
+     */
+    @Override
+    public void deviceEntered(NetworkDevice device) {
+        if (device == null)
+            return;
 
-		// verify if already know this device.
-		UpDevice upDevice = retrieveDevice(deviceHost, device.getNetworkDeviceType());
+        // verify if device entered is the current device
+        String deviceHost = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
+        for (UpNetworkInterface networkInterface : this.currentDevice.getNetworks()) {
+            String currentDeviceHost = connectionManagerControlCenter.getHost(networkInterface.getNetworkAddress());
+            if (deviceHost != null && deviceHost.equals(currentDeviceHost)) {
+                logger.fine("Host of device entered is the same of current device:" + device.getNetworkDeviceName());
+                return;
+            }
+        }
 
-		if (upDevice == null) {
-			upDevice = doHandshake(device, upDevice);
-			if (upDevice != null) {
-				doDriversRegistry(device, upDevice);
-			}
-		} else {
-			logger.fine("Already known device " + device.getNetworkDeviceName());
-		}
-	}
+        // verify if already know this device.
+        UpDevice upDevice = retrieveDevice(deviceHost, device.getNetworkDeviceType());
 
-	private void doDriversRegistry(NetworkDevice device, UpDevice upDevice) {
-		try {
-			Response response = gateway.callService(upDevice, new Call(DEVICE_DRIVER_NAME, "listDrivers"));
-			if (response != null && response.getResponseData() != null
-					&& response.getResponseData("driverList") != null) {
-				try {
-					ObjectNode driversListMap = null;
-					Object temp = response.getResponseData("driverList");
-					if (temp instanceof ObjectNode)
-						driversListMap = (ObjectNode) temp; // TODO: Not tested, why?
-					else
-						driversListMap = (ObjectNode) mapper.readTree(temp.toString());
+        if (upDevice == null) {
+            upDevice = doHandshake(device, upDevice);
+            if (upDevice != null) {
+                doDriversRegistry(device, upDevice);
+                fireDeviceEvent(upDevice, DeviceEventType.ENTERED);
+            }
+        } else {
+            logger.fine("Already known device " + device.getNetworkDeviceName());
+        }
+    }
 
-					List<String> ids = new ArrayList<String>();
-					Iterator<String> it = driversListMap.fieldNames();
-					while (it.hasNext())
-						ids.add(it.next());
+    private void doDriversRegistry(NetworkDevice device, UpDevice upDevice) {
+        try {
+            Response response = gateway.callService(upDevice, new Call(DEVICE_DRIVER_NAME, "listDrivers"));
+            if (response != null && response.getResponseData() != null && response.getResponseData("driverList") != null) {
+                try {
+                    JavaType mapType = mapper.getTypeFactory().constructParametrizedType(Map.class, Map.class, String.class, UpDriver.class);
+                    Map<String, UpDriver> driverList = mapper.convertValue(response.getResponseData("driverList"), mapType);
+                    registerRemoteDriverInstances(upDevice, driverList);
+                } catch (IOException e) {
+                    logger.log(Level.SEVERE, "Problems ocurred in the registering of drivers from device '" + upDevice.getName() + "' .", e);
+                }
+            }
+        } catch (Exception e) {
+            logger.severe("Not possible to discover services from device '" + device.getNetworkDeviceName() + "'. Possibly not a uOS Device");
+        }
+    }
 
-					registerRemoteDriverInstances(upDevice, driversListMap, ids);
-				} catch (IOException e) {
-					logger.log(Level.SEVERE,
-							"Problems ocurred in the registering of drivers from device '" + upDevice.getName() + "' .",
-							e);
-				}
-			}
-		} catch (Exception e) {
-			logger.severe("Not possible to discover services from device '" + device.getNetworkDeviceName()
-					+ "'. Possibly not a uOS Device");
-		}
-	}
+    private void registerRemoteDriverInstances(UpDevice upDevice, Map<String, UpDriver> driversListMap) throws IOException {
+        for (Map.Entry<String, UpDriver> entry : driversListMap.entrySet()) {
+            String id = entry.getKey();
+            UpDriver upDriver = entry.getValue();
+            DriverModel driverModel = new DriverModel(id, upDriver, upDevice.getName());
+            try {
+                driverManager.insert(driverModel);
+                // TODO : DeviceManager : Save the device information
+                if (this.connectivityManager.doProxying()) {
+                    this.connectivityManager.registerProxyDriver(upDriver, upDevice, id);
+                }
+            } catch (DriverManagerException e) {
+                logger.log(Level.SEVERE,
+                        "Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
+                                + id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
+                        e);
+            } catch (DriverNotFoundException e) {
+                unknownDrivers.addAll(e.getDriversName());
+                dependents.add(driverModel);
 
-	private void registerRemoteDriverInstances(UpDevice upDevice, ObjectNode driversListMap, List<String> instanceIds)
-			throws IOException {
-		for (String id : instanceIds) {
-			UpDriver upDriver = mapper.readValue(mapper.writeValueAsString(driversListMap.get(id)), UpDriver.class);
-			DriverModel driverModel = new DriverModel(id, upDriver, upDevice.getName());
+            } catch (RuntimeException e) {
+                logger.log(Level.SEVERE,
+                        "Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
+                                + id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
+                        e);
+            }
+        }
+        if (unknownDrivers.size() > 0)
+            findDrivers(unknownDrivers, upDevice);
+    }
 
-			try {
-				driverManager.insert(driverModel);
-				// TODO : DeviceManager : Save the device information
-				if (this.connectivityManager.doProxying()) {
-					this.connectivityManager.registerProxyDriver(upDriver, upDevice, id);
-				}
-			} catch (DriverManagerException e) {
-				logger.log(Level.SEVERE,
-						"Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
-								+ id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
-						e);
-			} catch (DriverNotFoundException e) {
-				unknownDrivers.addAll(e.getDriversName());
-				dependents.add(driverModel);
+    /**
+     * @param upDevice
+     * @param e
+     * @return
+     * @throws JSONException
+     * @throws ServiceCallException
+     */
+    private void findDrivers(Set<String> unknownDrivers, UpDevice upDevice) throws IOException {
+        Call call = new Call(DEVICE_DRIVER_NAME, "tellEquivalentDrivers", null);
+        call.addParameter(DRIVERS_NAME_KEY, new ArrayList<String>(unknownDrivers));
 
-			} catch (RuntimeException e) {
-				logger.log(Level.SEVERE,
-						"Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
-								+ id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
-						e);
-			}
-		}
-		if (unknownDrivers.size() > 0)
-			findDrivers(unknownDrivers, upDevice);
-	}
+        try {
+            Response equivalentDriverResponse = gateway.callService(upDevice, call);
 
-	/**
-	 * @param upDevice
-	 * @param e
-	 * @return
-	 * @throws JSONException
-	 * @throws ServiceCallException
-	 */
-	private void findDrivers(Set<String> unknownDrivers, UpDevice upDevice) throws IOException {
-		Call call = new Call(DEVICE_DRIVER_NAME, "tellEquivalentDrivers", null);
-		call.addParameter(DRIVERS_NAME_KEY, mapper.writeValueAsString(unknownDrivers.toArray()));
+            if (equivalentDriverResponse != null && (equivalentDriverResponse.getError() == null || equivalentDriverResponse.getError().isEmpty())) {
+                Object interfaces = equivalentDriverResponse.getResponseData(INTERFACES_KEY);
+                if (interfaces != null) {
+                    JavaType listType = mapper.getTypeFactory().constructParametrizedType(List.class, List.class, UpDriver.class);
+                    List<UpDriver> drivers = mapper.convertValue(interfaces, listType);
 
-		try {
-			Response equivalentDriverResponse = gateway.callService(upDevice, call);
+                    try {
+                        driverManager.addToEquivalenceTree(drivers);
+                    } catch (InterfaceValidationException e) {
+                        logger.severe("Not possible to add to equivalance tree due to wrong interface specification.");
+                    }
 
-			if (equivalentDriverResponse != null
-					&& (equivalentDriverResponse.getError() == null || equivalentDriverResponse.getError().isEmpty())) {
+                    for (DriverModel dependent : dependents) {
+                        try {
+                            driverManager.insert(dependent);
+                        } catch (DriverManagerException e) {
+                            logger.log(Level.SEVERE,
+                                    "Problems ocurred in the registering of driver '" + dependent.driver().getName()
+                                            + "' with instanceId '" + dependent.id() + "' in the device '"
+                                            + upDevice.getName() + "' and it will not be registered.",
+                                    e
+                            );
+                        } catch (DriverNotFoundException e) {
+                            logger.severe("Not possible to register driver '" + dependent.driver().getName() + "' due to unkwnown equivalent driver.");
+                        }
+                    }
 
-				String interfaces = equivalentDriverResponse.getResponseString(INTERFACES_KEY);
+                } else {
+                    logger.severe("Not possible to call service on device '" + upDevice.getName() + "' for no equivalent drivers on the service response.");
+                }
+            } else {
+                logger.severe("Not possible to call service on device '" + upDevice.getName() + (equivalentDriverResponse == null ?
+                        ": null"
+                        : "': Cause : " + equivalentDriverResponse.getError())
+                );
+            }
+        } catch (ServiceCallException e) {
+            logger.severe("Not possible to call service on device '" + upDevice.getName());
+        }
+    }
 
-				if (interfaces != null) {
+    @SuppressWarnings("rawtypes")
+    private UpDevice doHandshake(NetworkDevice device, UpDevice upDevice) {
+        try {
+            // Create a Dummy device just for calling it
+            logger.fine("Trying to hanshake with device : " + device.getNetworkDeviceName());
+            UpDevice dummyDevice = new UpDevice(device.getNetworkDeviceName())
+                    .addNetworkInterface(device.getNetworkDeviceName(), device.getNetworkDeviceType());
 
-					List<UpDriver> drivers = new ArrayList<UpDriver>();
+            Call call = new Call(DEVICE_DRIVER_NAME, "handshake", null);
+            call.addParameter("device", currentDevice);
 
-					ArrayNode interfacesJson = (ArrayNode) mapper.readTree(interfaces);
-					for (JsonNode node : interfacesJson) {
-						UpDriver upDriver = mapper.readValue(node.isTextual() ? node.asText() : node.toString(), UpDriver.class);
-						drivers.add(upDriver);
-					}
+            Response response = gateway.callService(dummyDevice, call);
+            if (response != null && (response.getError() == null || response.getError().isEmpty())) {
+                // in case of a success greeting process, register the device in
+                // the neighborhood database
+                Object responseDevice = response.getResponseData("device");
+                if (responseDevice != null) {
+                    UpDevice remoteDevice = (responseDevice instanceof String) ?
+                        mapper.readValue((String) responseDevice, UpDevice.class) : mapper.convertValue(responseDevice, UpDevice.class);
+                    registerDevice(remoteDevice);
+                    logger.info("Registered device " + remoteDevice.getName());
+                    return remoteDevice;
+                } else {
+                    logger.severe("Not possible complete handshake with device '" + device.getNetworkDeviceName()
+                            + "' for no device on the handshake response.");
+                }
+            } else {
+                logger.severe("Not possible to handshake with device '" + device.getNetworkDeviceName()
+                        + (response == null ? ": No Response received." : "': Cause : " + response.getError()));
+            }
+        } catch (Exception e) {
+            logger.severe(
+                    "Not possible to handshake with device '" + device.getNetworkDeviceName() + "'. " + e.getMessage());
+        }
+        return upDevice;
+    }
 
-					try {
-						driverManager.addToEquivalenceTree(drivers);
-					} catch (InterfaceValidationException e) {
-						logger.severe("Not possible to add to equivalance tree due to wrong interface specification.");
-					}
+    /**
+     * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceLeft(org.unbiquitous.uos.core.network.model.NetworkDevice)
+     */
+    @Override
+    public void deviceLeft(NetworkDevice device) {
+        if (device == null || device.getNetworkDeviceName() == null || device.getNetworkDeviceType() == null)
+            return;
+        // Remove what services this device has.
+        logger.info(
+                "Device " + device.getNetworkDeviceName() + " of type " + device.getNetworkDeviceType() + " leaving.");
+        String host = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
+        List<UpDevice> devices = deviceDao.list(host, device.getNetworkDeviceType());
 
-					for (DriverModel dependent : dependents) {
-						try {
-							driverManager.insert(dependent);
-						} catch (DriverManagerException e) {
-							logger.log(Level.SEVERE,
-									"Problems ocurred in the registering of driver '" + dependent.driver().getName()
-											+ "' with instanceId '" + dependent.id() + "' in the device '"
-											+ upDevice.getName() + "' and it will not be registered.",
-									e);
-						} catch (DriverNotFoundException e) {
-							logger.severe("Not possible to register driver '" + dependent.driver().getName()
-									+ "' due to unkwnown equivalent driver.");
-						}
-					}
+        if (devices != null && !devices.isEmpty()) {
+            UpDevice upDevice = devices.get(0);
+            List<DriverModel> returnedDrivers = driverManager.list(null, upDevice.getName());
+            if (returnedDrivers != null && !returnedDrivers.isEmpty()) {
+                for (DriverModel rdd : returnedDrivers) {
+                    driverManager.delete(rdd.id(), rdd.device());
+                }
+            }
+            deviceDao.delete(upDevice.getName());
+            fireDeviceEvent(upDevice, DeviceEventType.LEFT);
+            logger.info(String.format("Device '%s' left", upDevice.getName()));
+        } else {
+            logger.info("Device not found in database.");
+        }
+    }
 
-				} else {
-					logger.severe("Not possible to call service on device '" + upDevice.getName()
-							+ "' for no equivalent drivers on the service response.");
-				}
-			} else {
-				logger.severe("Not possible to call service on device '" + upDevice.getName()
-						+ (equivalentDriverResponse == null ? ": null"
-								: "': Cause : " + equivalentDriverResponse.getError()));
-			}
-		} catch (ServiceCallException e) {
-			logger.severe("Not possible to call service on device '" + upDevice.getName());
-		}
-	}
+    public List<UpDevice> listDevices() {
+        return deviceDao.list();
+    }
 
-	@SuppressWarnings("rawtypes")
-	private UpDevice doHandshake(NetworkDevice device, UpDevice upDevice) {
-		try {
-			// Create a Dummy device just for calling it
-			logger.fine("Trying to hanshake with device : " + device.getNetworkDeviceName());
-			UpDevice dummyDevice = new UpDevice(device.getNetworkDeviceName())
-					.addNetworkInterface(device.getNetworkDeviceName(), device.getNetworkDeviceType());
+    public DeviceDao getDeviceDao() {
+        return deviceDao;
+    }
 
-			Call call = new Call(DEVICE_DRIVER_NAME, "handshake", null);
-			call.addParameter("device", mapper.writeValueAsString(currentDevice));
+    /**
+     * Adds a new listener to the device manager, that will be notified whenever a previously unknown device is
+     * successfully registered or a previously registered device is unregistered due to leaving the smartspace.
+     *
+     * @param listener the new listener to be added.
+     * @throws NullPointerException if listener is null.
+     */
+    public void addDeviceListener(DeviceListener listener) {
+        if (listener == null)
+            throw new NullPointerException("listener");
+        deviceListeners.add(listener);
+    }
 
-			Response response = gateway.callService(dummyDevice, call);
-			if (response != null && (response.getError() == null || response.getError().isEmpty())) {
-				// in case of a success greeting process, register the device in
-				// the neighborhood database
-				Object responseDevice = response.getResponseData("device");
-				if (responseDevice != null) {
-					UpDevice remoteDevice;
-					if (responseDevice instanceof String) {
-						remoteDevice = mapper.readValue((String) responseDevice, UpDevice.class);
-					} else if (responseDevice instanceof Map) {
-						remoteDevice = mapper.treeToValue(mapper.valueToTree((Map) responseDevice), UpDevice.class);
-					} else {
-						remoteDevice = mapper.treeToValue((JsonNode) responseDevice, UpDevice.class);
-					}
-					registerDevice(remoteDevice);
-					logger.info("Registered device " + remoteDevice.getName());
-					return remoteDevice;
-				} else {
-					logger.severe("Not possible complete handshake with device '" + device.getNetworkDeviceName()
-							+ "' for no device on the handshake response.");
-				}
-			} else {
-				logger.severe("Not possible to handshake with device '" + device.getNetworkDeviceName()
-						+ (response == null ? ": No Response received." : "': Cause : " + response.getError()));
-			}
-		} catch (Exception e) {
-			logger.severe(
-					"Not possible to handshake with device '" + device.getNetworkDeviceName() + "'. " + e.getMessage());
-		}
-		return upDevice;
-	}
+    /**
+     * Removes a previously added listener. If listener is null or was not previously added,
+     * nothing happens.
+     *
+     * @param listener the listener to be removed.
+     */
+    public void removeDeviceListener(DeviceListener listener) {
+        deviceListeners.remove(listener);
+    }
 
-	/**
-	 * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceLeft(org.unbiquitous.uos.core.network.model.NetworkDevice)
-	 */
-	@Override
-	public void deviceLeft(NetworkDevice device) {
-		if (device == null || device.getNetworkDeviceName() == null || device.getNetworkDeviceType() == null)
-			return;
-		// Remove what services this device has.
-		logger.info(
-				"Device " + device.getNetworkDeviceName() + " of type " + device.getNetworkDeviceType() + " leaving.");
-		String host = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
-		List<UpDevice> devices = deviceDao.list(host, device.getNetworkDeviceType());
+    private enum DeviceEventType {ENTERED, LEFT}
 
-		if (devices != null && !devices.isEmpty()) {
-			UpDevice upDevice = devices.get(0);
-			List<DriverModel> returnedDrivers = driverManager.list(null, upDevice.getName());
-			if (returnedDrivers != null && !returnedDrivers.isEmpty()) {
-				for (DriverModel rdd : returnedDrivers) {
-					driverManager.delete(rdd.id(), rdd.device());
-				}
-			}
-			deviceDao.delete(upDevice.getName());
-			logger.info(String.format("Device '%s' left", upDevice.getName()));
-		} else {
-			logger.info("Device not found in database.");
-		}
-
-	}
-
-	public List<UpDevice> listDevices() {
-		return deviceDao.list();
-	}
-
-	public DeviceDao getDeviceDao() {
-		return deviceDao;
-	}
+    private void fireDeviceEvent(UpDevice device, DeviceEventType type) {
+        try {
+            Method m = ((type == DeviceEventType.ENTERED) ?
+                    DeviceListener.class.getMethod("deviceRegistered", UpDevice.class) :
+                    DeviceListener.class.getMethod("deviceUnregistered", UpDevice.class));
+            for (DeviceListener l : deviceListeners)
+                try {
+                    m.invoke(l, device);
+                } catch (Throwable t) {
+                    logger.log(Level.WARNING, "Failed to notify device listener of event.", t);
+                }
+        } catch (NoSuchMethodException e) {
+            logger.log(Level.SEVERE, "Failed to load DeviceListener methods.", e);
+        }
+    }
 }

--- a/src/org/unbiquitous/uos/core/deviceManager/DeviceManager.java
+++ b/src/org/unbiquitous/uos/core/deviceManager/DeviceManager.java
@@ -1,6 +1,7 @@
 package org.unbiquitous.uos.core.deviceManager;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -37,331 +38,371 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 /**
  * Class responsible for managing the devices in the neighborhood of the current
  * device.
- * 
+ *
  * @author Fabricio Nogueira Buzeto
- * 
  */
 public class DeviceManager implements RadarListener {
 
-	private static final String DEVICE_DRIVER_NAME = "uos.DeviceDriver";
+    private static final String DEVICE_DRIVER_NAME = "uos.DeviceDriver";
 
-	private static final String DRIVERS_NAME_KEY = "driversName";
+    private static final String DRIVERS_NAME_KEY = "driversName";
 
-	private static final String INTERFACES_KEY = "interfaces";
+    private static final String INTERFACES_KEY = "interfaces";
 
-	private static final Logger logger = UOSLogging.getLogger();
-	private static final ObjectMapper mapper = new ObjectMapper();
+    private static final Logger logger = UOSLogging.getLogger();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-	private Gateway gateway;
+    private Gateway gateway;
 
-	private ConnectionManagerControlCenter connectionManagerControlCenter;
+    private ConnectionManagerControlCenter connectionManagerControlCenter;
 
-	private DeviceDao deviceDao;
+    private DeviceDao deviceDao;
 
-	private UpDevice currentDevice;
+    private UpDevice currentDevice;
 
-	private ConnectivityManager connectivityManager;
+    private ConnectivityManager connectivityManager;
 
-	private DriverManager driverManager;
+    private DriverManager driverManager;
 
-	private Set<String> unknownDrivers;
+    private Set<String> unknownDrivers;
 
-	private Set<DriverModel> dependents;
+    private Set<DriverModel> dependents;
 
-	public DeviceManager(UpDevice currentDevice, DeviceDao deviceDao, DriverDao driverDao,
-			ConnectionManagerControlCenter connectionManagerControlCenter, ConnectivityManager connectivityManager,
-			Gateway gateway, DriverManager driverManager) {
-		this.gateway = gateway;
-		this.connectionManagerControlCenter = connectionManagerControlCenter;
-		this.currentDevice = currentDevice;
-		this.connectivityManager = connectivityManager;
-		this.deviceDao = deviceDao;
-		this.deviceDao.save(currentDevice);
-		this.driverManager = driverManager;
-		this.unknownDrivers = new HashSet<String>();
-		this.dependents = new HashSet<DriverModel>();
-	}
+    private Set<DeviceListener> deviceListeners;
 
-	/**
-	 * Method responsible for registering a device in the neighborhood of the
-	 * current device.
-	 * 
-	 * @param device
-	 *            Device to be registered.
-	 */
-	public void registerDevice(UpDevice device) {
-		deviceDao.save(device);
-	}
+    public DeviceManager(UpDevice currentDevice, DeviceDao deviceDao, DriverDao driverDao,
+                         ConnectionManagerControlCenter connectionManagerControlCenter, ConnectivityManager connectivityManager,
+                         Gateway gateway, DriverManager driverManager) {
+        this.gateway = gateway;
+        this.connectionManagerControlCenter = connectionManagerControlCenter;
+        this.currentDevice = currentDevice;
+        this.connectivityManager = connectivityManager;
+        this.deviceDao = deviceDao;
+        this.deviceDao.save(currentDevice);
+        this.driverManager = driverManager;
+        this.unknownDrivers = new HashSet<String>();
+        this.dependents = new HashSet<DriverModel>();
+        this.deviceListeners = new HashSet<DeviceListener>();
+    }
 
-	/**
-	 * Method responsible for finding the data about a device present in the
-	 * neighborhood.
-	 * 
-	 * @param deviceName
-	 *            Device name to be found.
-	 * @return <code>UpDevice</code> with the data about the informed device.
-	 */
-	public UpDevice retrieveDevice(String deviceName) {
-		return deviceDao.find(deviceName);
-	}
+    /**
+     * Method responsible for registering a device in the neighborhood of the
+     * current device.
+     *
+     * @param device Device to be registered.
+     */
+    public void registerDevice(UpDevice device) {
+        deviceDao.save(device);
+    }
 
-	/**
-	 * Method responsible for finding the data about a device present in the
-	 * neighborhood.
-	 * 
-	 * @param networkAddress
-	 *            Address of the Device to be found.
-	 * @param networkType
-	 *            NetworkType of Address of the Device to be found.
-	 * @return <code>UpDevice</code> with the data about the informed device.
-	 */
-	public UpDevice retrieveDevice(String networkAddress, String networkType) {
-		List<UpDevice> list = deviceDao.list(networkAddress, networkType);
-		if (list != null && !list.isEmpty()) {
-			UpDevice deviceFound = list.get(0);
-			logger.fine("Device with addr '" + networkAddress + "' found on network '" + networkType + "' resolved to "
-					+ deviceFound);
-			return deviceFound;
-		}
-		logger.fine("No device found with addr '" + networkAddress + "' on network '" + networkType + "'.");
-		return null;
-	}
+    /**
+     * Method responsible for finding the data about a device present in the
+     * neighborhood.
+     *
+     * @param deviceName Device name to be found.
+     * @return <code>UpDevice</code> with the data about the informed device.
+     */
+    public UpDevice retrieveDevice(String deviceName) {
+        return deviceDao.find(deviceName);
+    }
 
-	/**
-	 * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceEntered(org.unbiquitous.uos.core.network.model.NetworkDevice)
-	 */
-	@Override
-	public void deviceEntered(NetworkDevice device) {
-		if (device == null)
-			return;
+    /**
+     * Method responsible for finding the data about a device present in the
+     * neighborhood.
+     *
+     * @param networkAddress Address of the Device to be found.
+     * @param networkType    NetworkType of Address of the Device to be found.
+     * @return <code>UpDevice</code> with the data about the informed device.
+     */
+    public UpDevice retrieveDevice(String networkAddress, String networkType) {
+        List<UpDevice> list = deviceDao.list(networkAddress, networkType);
+        if (list != null && !list.isEmpty()) {
+            UpDevice deviceFound = list.get(0);
+            logger.fine("Device with addr '" + networkAddress + "' found on network '" + networkType + "' resolved to "
+                    + deviceFound);
+            return deviceFound;
+        }
+        logger.fine("No device found with addr '" + networkAddress + "' on network '" + networkType + "'.");
+        return null;
+    }
 
-		// verify if device entered is the current device
-		String deviceHost = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
-		for (UpNetworkInterface networkInterface : this.currentDevice.getNetworks()) {
-			String currentDeviceHost = connectionManagerControlCenter.getHost(networkInterface.getNetworkAddress());
-			if (deviceHost != null && deviceHost.equals(currentDeviceHost)) {
-				logger.fine("Host of device entered is the same of current device:" + device.getNetworkDeviceName());
-				return;
-			}
-		}
+    /**
+     * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceEntered(org.unbiquitous.uos.core.network.model.NetworkDevice)
+     */
+    @Override
+    public void deviceEntered(NetworkDevice device) {
+        if (device == null)
+            return;
 
-		// verify if already know this device.
-		UpDevice upDevice = retrieveDevice(deviceHost, device.getNetworkDeviceType());
+        // verify if device entered is the current device
+        String deviceHost = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
+        for (UpNetworkInterface networkInterface : this.currentDevice.getNetworks()) {
+            String currentDeviceHost = connectionManagerControlCenter.getHost(networkInterface.getNetworkAddress());
+            if (deviceHost != null && deviceHost.equals(currentDeviceHost)) {
+                logger.fine("Host of device entered is the same of current device:" + device.getNetworkDeviceName());
+                return;
+            }
+        }
 
-		if (upDevice == null) {
-			upDevice = doHandshake(device, upDevice);
-			if (upDevice != null) {
-				doDriversRegistry(device, upDevice);
-			}
-		} else {
-			logger.fine("Already known device " + device.getNetworkDeviceName());
-		}
-	}
+        // verify if already know this device.
+        UpDevice upDevice = retrieveDevice(deviceHost, device.getNetworkDeviceType());
 
-	private void doDriversRegistry(NetworkDevice device, UpDevice upDevice) {
-		try {
-			Response response = gateway.callService(upDevice, new Call(DEVICE_DRIVER_NAME, "listDrivers"));
-			if (response != null && response.getResponseData() != null
-					&& response.getResponseData("driverList") != null) {
-				try {
-					ObjectNode driversListMap = null;
-					Object temp = response.getResponseData("driverList");
-					if (temp instanceof ObjectNode)
-						driversListMap = (ObjectNode) temp; // TODO: Not tested, why?
-					else
-						driversListMap = (ObjectNode) mapper.readTree(temp.toString());
+        if (upDevice == null) {
+            upDevice = doHandshake(device, upDevice);
+            if (upDevice != null) {
+                doDriversRegistry(device, upDevice);
+            }
+        } else {
+            logger.fine("Already known device " + device.getNetworkDeviceName());
+        }
+    }
 
-					List<String> ids = new ArrayList<String>();
-					Iterator<String> it = driversListMap.fieldNames();
-					while (it.hasNext())
-						ids.add(it.next());
+    private void doDriversRegistry(NetworkDevice device, UpDevice upDevice) {
+        try {
+            Response response = gateway.callService(upDevice, new Call(DEVICE_DRIVER_NAME, "listDrivers"));
+            if (response != null && response.getResponseData() != null
+                    && response.getResponseData("driverList") != null) {
+                try {
+                    ObjectNode driversListMap = null;
+                    Object temp = response.getResponseData("driverList");
+                    if (temp instanceof ObjectNode)
+                        driversListMap = (ObjectNode) temp; // TODO: Not tested, why?
+                    else
+                        driversListMap = (ObjectNode) mapper.readTree(temp.toString());
 
-					registerRemoteDriverInstances(upDevice, driversListMap, ids);
-				} catch (IOException e) {
-					logger.log(Level.SEVERE,
-							"Problems ocurred in the registering of drivers from device '" + upDevice.getName() + "' .",
-							e);
-				}
-			}
-		} catch (Exception e) {
-			logger.severe("Not possible to discover services from device '" + device.getNetworkDeviceName()
-					+ "'. Possibly not a uOS Device");
-		}
-	}
+                    List<String> ids = new ArrayList<String>();
+                    Iterator<String> it = driversListMap.fieldNames();
+                    while (it.hasNext())
+                        ids.add(it.next());
 
-	private void registerRemoteDriverInstances(UpDevice upDevice, ObjectNode driversListMap, List<String> instanceIds)
-			throws IOException {
-		for (String id : instanceIds) {
-			UpDriver upDriver = mapper.readValue(mapper.writeValueAsString(driversListMap.get(id)), UpDriver.class);
-			DriverModel driverModel = new DriverModel(id, upDriver, upDevice.getName());
+                    registerRemoteDriverInstances(upDevice, driversListMap, ids);
+                } catch (IOException e) {
+                    logger.log(Level.SEVERE,
+                            "Problems ocurred in the registering of drivers from device '" + upDevice.getName() + "' .",
+                            e);
+                }
+            }
+        } catch (Exception e) {
+            logger.severe("Not possible to discover services from device '" + device.getNetworkDeviceName()
+                    + "'. Possibly not a uOS Device");
+        }
+    }
 
-			try {
-				driverManager.insert(driverModel);
-				// TODO : DeviceManager : Save the device information
-				if (this.connectivityManager.doProxying()) {
-					this.connectivityManager.registerProxyDriver(upDriver, upDevice, id);
-				}
-			} catch (DriverManagerException e) {
-				logger.log(Level.SEVERE,
-						"Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
-								+ id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
-						e);
-			} catch (DriverNotFoundException e) {
-				unknownDrivers.addAll(e.getDriversName());
-				dependents.add(driverModel);
+    private void registerRemoteDriverInstances(UpDevice upDevice, ObjectNode driversListMap, List<String> instanceIds)
+            throws IOException {
+        for (String id : instanceIds) {
+            UpDriver upDriver = mapper.readValue(mapper.writeValueAsString(driversListMap.get(id)), UpDriver.class);
+            DriverModel driverModel = new DriverModel(id, upDriver, upDevice.getName());
 
-			} catch (RuntimeException e) {
-				logger.log(Level.SEVERE,
-						"Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
-								+ id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
-						e);
-			}
-		}
-		if (unknownDrivers.size() > 0)
-			findDrivers(unknownDrivers, upDevice);
-	}
+            try {
+                driverManager.insert(driverModel);
+                // TODO : DeviceManager : Save the device information
+                if (this.connectivityManager.doProxying()) {
+                    this.connectivityManager.registerProxyDriver(upDriver, upDevice, id);
+                }
+            } catch (DriverManagerException e) {
+                logger.log(Level.SEVERE,
+                        "Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
+                                + id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
+                        e);
+            } catch (DriverNotFoundException e) {
+                unknownDrivers.addAll(e.getDriversName());
+                dependents.add(driverModel);
 
-	/**
-	 * @param upDevice
-	 * @param e
-	 * @return
-	 * @throws JSONException
-	 * @throws ServiceCallException
-	 */
-	private void findDrivers(Set<String> unknownDrivers, UpDevice upDevice) throws IOException {
-		Call call = new Call(DEVICE_DRIVER_NAME, "tellEquivalentDrivers", null);
-		call.addParameter(DRIVERS_NAME_KEY, mapper.writeValueAsString(unknownDrivers.toArray()));
+            } catch (RuntimeException e) {
+                logger.log(Level.SEVERE,
+                        "Problems ocurred in the registering of driver '" + upDriver.getName() + "' with instanceId '"
+                                + id + "' in the device '" + upDevice.getName() + "' and it will not be registered.",
+                        e);
+            }
+        }
+        if (unknownDrivers.size() > 0)
+            findDrivers(unknownDrivers, upDevice);
+    }
 
-		try {
-			Response equivalentDriverResponse = gateway.callService(upDevice, call);
+    /**
+     * @param upDevice
+     * @param e
+     * @return
+     * @throws JSONException
+     * @throws ServiceCallException
+     */
+    private void findDrivers(Set<String> unknownDrivers, UpDevice upDevice) throws IOException {
+        Call call = new Call(DEVICE_DRIVER_NAME, "tellEquivalentDrivers", null);
+        call.addParameter(DRIVERS_NAME_KEY, mapper.writeValueAsString(unknownDrivers.toArray()));
 
-			if (equivalentDriverResponse != null
-					&& (equivalentDriverResponse.getError() == null || equivalentDriverResponse.getError().isEmpty())) {
+        try {
+            Response equivalentDriverResponse = gateway.callService(upDevice, call);
 
-				String interfaces = equivalentDriverResponse.getResponseString(INTERFACES_KEY);
+            if (equivalentDriverResponse != null
+                    && (equivalentDriverResponse.getError() == null || equivalentDriverResponse.getError().isEmpty())) {
 
-				if (interfaces != null) {
+                String interfaces = equivalentDriverResponse.getResponseString(INTERFACES_KEY);
 
-					List<UpDriver> drivers = new ArrayList<UpDriver>();
+                if (interfaces != null) {
 
-					ArrayNode interfacesJson = (ArrayNode) mapper.readTree(interfaces);
-					for (JsonNode node : interfacesJson) {
-						UpDriver upDriver = mapper.readValue(node.isTextual() ? node.asText() : node.toString(), UpDriver.class);
-						drivers.add(upDriver);
-					}
+                    List<UpDriver> drivers = new ArrayList<UpDriver>();
 
-					try {
-						driverManager.addToEquivalenceTree(drivers);
-					} catch (InterfaceValidationException e) {
-						logger.severe("Not possible to add to equivalance tree due to wrong interface specification.");
-					}
+                    ArrayNode interfacesJson = (ArrayNode) mapper.readTree(interfaces);
+                    for (JsonNode node : interfacesJson) {
+                        UpDriver upDriver = mapper.readValue(node.isTextual() ? node.asText() : node.toString(), UpDriver.class);
+                        drivers.add(upDriver);
+                    }
 
-					for (DriverModel dependent : dependents) {
-						try {
-							driverManager.insert(dependent);
-						} catch (DriverManagerException e) {
-							logger.log(Level.SEVERE,
-									"Problems ocurred in the registering of driver '" + dependent.driver().getName()
-											+ "' with instanceId '" + dependent.id() + "' in the device '"
-											+ upDevice.getName() + "' and it will not be registered.",
-									e);
-						} catch (DriverNotFoundException e) {
-							logger.severe("Not possible to register driver '" + dependent.driver().getName()
-									+ "' due to unkwnown equivalent driver.");
-						}
-					}
+                    try {
+                        driverManager.addToEquivalenceTree(drivers);
+                    } catch (InterfaceValidationException e) {
+                        logger.severe("Not possible to add to equivalance tree due to wrong interface specification.");
+                    }
 
-				} else {
-					logger.severe("Not possible to call service on device '" + upDevice.getName()
-							+ "' for no equivalent drivers on the service response.");
-				}
-			} else {
-				logger.severe("Not possible to call service on device '" + upDevice.getName()
-						+ (equivalentDriverResponse == null ? ": null"
-								: "': Cause : " + equivalentDriverResponse.getError()));
-			}
-		} catch (ServiceCallException e) {
-			logger.severe("Not possible to call service on device '" + upDevice.getName());
-		}
-	}
+                    for (DriverModel dependent : dependents) {
+                        try {
+                            driverManager.insert(dependent);
+                        } catch (DriverManagerException e) {
+                            logger.log(Level.SEVERE,
+                                    "Problems ocurred in the registering of driver '" + dependent.driver().getName()
+                                            + "' with instanceId '" + dependent.id() + "' in the device '"
+                                            + upDevice.getName() + "' and it will not be registered.",
+                                    e);
+                        } catch (DriverNotFoundException e) {
+                            logger.severe("Not possible to register driver '" + dependent.driver().getName()
+                                    + "' due to unkwnown equivalent driver.");
+                        }
+                    }
 
-	@SuppressWarnings("rawtypes")
-	private UpDevice doHandshake(NetworkDevice device, UpDevice upDevice) {
-		try {
-			// Create a Dummy device just for calling it
-			logger.fine("Trying to hanshake with device : " + device.getNetworkDeviceName());
-			UpDevice dummyDevice = new UpDevice(device.getNetworkDeviceName())
-					.addNetworkInterface(device.getNetworkDeviceName(), device.getNetworkDeviceType());
+                } else {
+                    logger.severe("Not possible to call service on device '" + upDevice.getName()
+                            + "' for no equivalent drivers on the service response.");
+                }
+            } else {
+                logger.severe("Not possible to call service on device '" + upDevice.getName()
+                        + (equivalentDriverResponse == null ? ": null"
+                        : "': Cause : " + equivalentDriverResponse.getError()));
+            }
+        } catch (ServiceCallException e) {
+            logger.severe("Not possible to call service on device '" + upDevice.getName());
+        }
+    }
 
-			Call call = new Call(DEVICE_DRIVER_NAME, "handshake", null);
-			call.addParameter("device", mapper.writeValueAsString(currentDevice));
+    @SuppressWarnings("rawtypes")
+    private UpDevice doHandshake(NetworkDevice device, UpDevice upDevice) {
+        try {
+            // Create a Dummy device just for calling it
+            logger.fine("Trying to hanshake with device : " + device.getNetworkDeviceName());
+            UpDevice dummyDevice = new UpDevice(device.getNetworkDeviceName())
+                    .addNetworkInterface(device.getNetworkDeviceName(), device.getNetworkDeviceType());
 
-			Response response = gateway.callService(dummyDevice, call);
-			if (response != null && (response.getError() == null || response.getError().isEmpty())) {
-				// in case of a success greeting process, register the device in
-				// the neighborhood database
-				Object responseDevice = response.getResponseData("device");
-				if (responseDevice != null) {
-					UpDevice remoteDevice;
-					if (responseDevice instanceof String) {
-						remoteDevice = mapper.readValue((String) responseDevice, UpDevice.class);
-					} else if (responseDevice instanceof Map) {
-						remoteDevice = mapper.treeToValue(mapper.valueToTree((Map) responseDevice), UpDevice.class);
-					} else {
-						remoteDevice = mapper.treeToValue((JsonNode) responseDevice, UpDevice.class);
-					}
-					registerDevice(remoteDevice);
-					logger.info("Registered device " + remoteDevice.getName());
-					return remoteDevice;
-				} else {
-					logger.severe("Not possible complete handshake with device '" + device.getNetworkDeviceName()
-							+ "' for no device on the handshake response.");
-				}
-			} else {
-				logger.severe("Not possible to handshake with device '" + device.getNetworkDeviceName()
-						+ (response == null ? ": No Response received." : "': Cause : " + response.getError()));
-			}
-		} catch (Exception e) {
-			logger.severe(
-					"Not possible to handshake with device '" + device.getNetworkDeviceName() + "'. " + e.getMessage());
-		}
-		return upDevice;
-	}
+            Call call = new Call(DEVICE_DRIVER_NAME, "handshake", null);
+            call.addParameter("device", mapper.writeValueAsString(currentDevice));
 
-	/**
-	 * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceLeft(org.unbiquitous.uos.core.network.model.NetworkDevice)
-	 */
-	@Override
-	public void deviceLeft(NetworkDevice device) {
-		if (device == null || device.getNetworkDeviceName() == null || device.getNetworkDeviceType() == null)
-			return;
-		// Remove what services this device has.
-		logger.info(
-				"Device " + device.getNetworkDeviceName() + " of type " + device.getNetworkDeviceType() + " leaving.");
-		String host = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
-		List<UpDevice> devices = deviceDao.list(host, device.getNetworkDeviceType());
+            Response response = gateway.callService(dummyDevice, call);
+            if (response != null && (response.getError() == null || response.getError().isEmpty())) {
+                // in case of a success greeting process, register the device in
+                // the neighborhood database
+                Object responseDevice = response.getResponseData("device");
+                if (responseDevice != null) {
+                    UpDevice remoteDevice;
+                    if (responseDevice instanceof String) {
+                        remoteDevice = mapper.readValue((String) responseDevice, UpDevice.class);
+                    } else if (responseDevice instanceof Map) {
+                        remoteDevice = mapper.treeToValue(mapper.valueToTree((Map) responseDevice), UpDevice.class);
+                    } else {
+                        remoteDevice = mapper.treeToValue((JsonNode) responseDevice, UpDevice.class);
+                    }
+                    registerDevice(remoteDevice);
+                    fireDeviceEvent(remoteDevice, DeviceEventType.ENTERED);
+                    logger.info("Registered device " + remoteDevice.getName());
+                    return remoteDevice;
+                } else {
+                    logger.severe("Not possible complete handshake with device '" + device.getNetworkDeviceName()
+                            + "' for no device on the handshake response.");
+                }
+            } else {
+                logger.severe("Not possible to handshake with device '" + device.getNetworkDeviceName()
+                        + (response == null ? ": No Response received." : "': Cause : " + response.getError()));
+            }
+        } catch (Exception e) {
+            logger.severe(
+                    "Not possible to handshake with device '" + device.getNetworkDeviceName() + "'. " + e.getMessage());
+        }
+        return upDevice;
+    }
 
-		if (devices != null && !devices.isEmpty()) {
-			UpDevice upDevice = devices.get(0);
-			List<DriverModel> returnedDrivers = driverManager.list(null, upDevice.getName());
-			if (returnedDrivers != null && !returnedDrivers.isEmpty()) {
-				for (DriverModel rdd : returnedDrivers) {
-					driverManager.delete(rdd.id(), rdd.device());
-				}
-			}
-			deviceDao.delete(upDevice.getName());
-			logger.info(String.format("Device '%s' left", upDevice.getName()));
-		} else {
-			logger.info("Device not found in database.");
-		}
+    /**
+     * @see org.unbiquitous.uos.core.network.radar.RadarListener#deviceLeft(org.unbiquitous.uos.core.network.model.NetworkDevice)
+     */
+    @Override
+    public void deviceLeft(NetworkDevice device) {
+        if (device == null || device.getNetworkDeviceName() == null || device.getNetworkDeviceType() == null)
+            return;
+        // Remove what services this device has.
+        logger.info(
+                "Device " + device.getNetworkDeviceName() + " of type " + device.getNetworkDeviceType() + " leaving.");
+        String host = connectionManagerControlCenter.getHost(device.getNetworkDeviceName());
+        List<UpDevice> devices = deviceDao.list(host, device.getNetworkDeviceType());
 
-	}
+        if (devices != null && !devices.isEmpty()) {
+            UpDevice upDevice = devices.get(0);
+            List<DriverModel> returnedDrivers = driverManager.list(null, upDevice.getName());
+            if (returnedDrivers != null && !returnedDrivers.isEmpty()) {
+                for (DriverModel rdd : returnedDrivers) {
+                    driverManager.delete(rdd.id(), rdd.device());
+                }
+            }
+            deviceDao.delete(upDevice.getName());
+            fireDeviceEvent(upDevice, DeviceEventType.LEFT);
+            logger.info(String.format("Device '%s' left", upDevice.getName()));
+        } else {
+            logger.info("Device not found in database.");
+        }
+    }
 
-	public List<UpDevice> listDevices() {
-		return deviceDao.list();
-	}
+    public List<UpDevice> listDevices() {
+        return deviceDao.list();
+    }
 
-	public DeviceDao getDeviceDao() {
-		return deviceDao;
-	}
+    public DeviceDao getDeviceDao() {
+        return deviceDao;
+    }
+
+    /**
+     * Adds a new listener to the device manager, that will be notified whenever a previously unknown device is
+     * successfully registered or a previously registered device is unregistered due to leaving the smartspace.
+     *
+     * @param listener the new listener to be added.
+     * @throws NullPointerException if listener is null.
+     */
+    public void addDeviceListener(DeviceListener listener) {
+        if (listener == null)
+            throw new NullPointerException("listener");
+        deviceListeners.add(listener);
+    }
+
+    /**
+     * Removes a previously added listener. If listener is null or was not previously added,
+     * nothing happens.
+     *
+     * @param listener the listener to be removed.
+     */
+    public void removeDeviceListener(DeviceListener listener) {
+        deviceListeners.remove(listener);
+    }
+
+    private enum DeviceEventType {ENTERED, LEFT}
+
+    private void fireDeviceEvent(UpDevice device, DeviceEventType type) {
+        try {
+            Method m = ((type == DeviceEventType.ENTERED) ?
+                    DeviceListener.class.getMethod("deviceRegistered", UpDevice.class) :
+                    DeviceListener.class.getMethod("deviceUnregistered", UpDevice.class));
+            for (DeviceListener l : deviceListeners)
+                try {
+                    m.invoke(l, device);
+                } catch (Throwable t) {
+                    logger.log(Level.WARNING, "Failed to notify device listener of event.", t);
+                }
+        } catch (NoSuchMethodException e) {
+            logger.log(Level.SEVERE, "Failed to load DeviceListener methods.", e);
+        }
+    }
 }

--- a/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
+++ b/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
@@ -154,13 +154,15 @@ public class DeviceDriver implements UosDriver {
         DeviceManager deviceManager = gtw.getDeviceManager();
 
         // Get and Convert the UpDevice Parameter
-        String deviceParameter = (String) serviceCall.getParameterString(DEVICE_KEY);
+        Object deviceParameter = serviceCall.getParameter(DEVICE_KEY);
         if (deviceParameter == null) {
             serviceResponse.setError("No 'device' parameter informed.");
             return;
         }
         try {
-            UpDevice device = mapper.readValue(deviceParameter, UpDevice.class);
+            UpDevice device = deviceParameter instanceof String ?
+                    mapper.readValue((String) deviceParameter, UpDevice.class) :
+                    mapper.convertValue(deviceParameter, UpDevice.class);
             // TODO : DeviceDriver : validate if the device doing the handshake
             // is the same that is in the parameter
             deviceManager.registerDevice(device);

--- a/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
+++ b/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
@@ -1,12 +1,8 @@
 package org.unbiquitous.uos.core.driver;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.unbiquitous.uos.core.AuthenticationHandler;
 import org.unbiquitous.uos.core.InitialProperties;
 import org.unbiquitous.uos.core.UOSLogging;
@@ -24,218 +20,215 @@ import org.unbiquitous.uos.core.messageEngine.dataType.UpService;
 import org.unbiquitous.uos.core.messageEngine.messages.Call;
 import org.unbiquitous.uos.core.messageEngine.messages.Response;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Driver responsible for providing information about the device.
- * 
- * @author Fabricio Nogueira Buzeto
  *
+ * @author Fabricio Nogueira Buzeto
  */
 public class DeviceDriver implements UosDriver {
-	private static Logger logger = UOSLogging.getLogger();
-	private static final ObjectMapper mapper = new ObjectMapper();
+    private static Logger logger = UOSLogging.getLogger();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-	private static final String DEVICE_KEY = "device";
-	private static final String SECURITY_TYPE_KEY = "securityType";
-	private static final String DRIVER_LIST_KEY = "driverList";
-	private static final String DRIVER_NAME_KEY = "driverName";
-	private static final String INTERFACES_KEY = "interfaces";
-	private static final String DRIVERS_NAME_KEY = "driversName";
+    private static final String DEVICE_KEY = "device";
+    private static final String SECURITY_TYPE_KEY = "securityType";
+    private static final String DRIVER_LIST_KEY = "driverList";
+    private static final String DRIVER_NAME_KEY = "driverName";
+    private static final String INTERFACES_KEY = "interfaces";
+    private static final String DRIVERS_NAME_KEY = "driversName";
 
-	private Gateway gateway;
-	private final UpDriver driver;
+    private Gateway gateway;
+    private final UpDriver driver;
 
-	public DeviceDriver() {
-		driver = new UpDriver("uos.DeviceDriver");
+    public DeviceDriver() {
+        driver = new UpDriver("uos.DeviceDriver");
 
-		driver.addService("listDrivers").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.OPTIONAL);
+        driver.addService("listDrivers").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.OPTIONAL);
 
-		driver.addService("authenticate").addParameter(SECURITY_TYPE_KEY, UpService.ParameterType.MANDATORY);
+        driver.addService("authenticate").addParameter(SECURITY_TYPE_KEY, UpService.ParameterType.MANDATORY);
 
-		driver.addService("goodbye");
+        driver.addService("goodbye");
 
-		driver.addService("handshake").addParameter(DEVICE_KEY, UpService.ParameterType.MANDATORY);
+        driver.addService("handshake").addParameter(DEVICE_KEY, UpService.ParameterType.MANDATORY);
 
-		driver.addService("tellEquivalentDriver").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.MANDATORY);
-	}
+        driver.addService("tellEquivalentDriver").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.MANDATORY);
+    }
 
-	@Override
-	public UpDriver getDriver() {
-		return driver;
-	}
+    @Override
+    public UpDriver getDriver() {
+        return driver;
+    }
 
-	@Override
-	public void init(Gateway gateway, InitialProperties properties, String instanceId) {
-		this.gateway = gateway;
-	}
+    @Override
+    public void init(Gateway gateway, InitialProperties properties, String instanceId) {
+        this.gateway = gateway;
+    }
 
-	@Override
-	public void destroy() {
-	}
+    @Override
+    public void destroy() {
+    }
 
-	@Override
-	public List<UpDriver> getParent() {
-		return null;
-	}
+    @Override
+    public List<UpDriver> getParent() {
+        return null;
+    }
 
-	/**
-	 * Service responsible for retrieving the list of Driver Instances present
-	 * in the underlying device. This listing service can have its result
-	 * filtered with the use of the parameters 'serviceName' or 'driverName'. It
-	 * responds in a single responseMap within the parameter 'driverList'
-	 */
-	@SuppressWarnings("unchecked")
-	public void listDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		logger.info("Handling DeviceDriverImpl#listDrivers service");
+    /**
+     * Service responsible for retrieving the list of Driver Instances present
+     * in the underlying device. This listing service can have its result
+     * filtered with the use of the parameters 'serviceName' or 'driverName'. It
+     * responds in a single responseMap within the parameter 'driverList'
+     */
+    @SuppressWarnings("unchecked")
+    public void listDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        logger.info("Handling DeviceDriverImpl#listDrivers service");
 
-		List<DriverData> listDrivers = null;
+        List<DriverData> listDrivers = null;
 
-		Map<String, Object> parameters = serviceCall.getParameters();
+        Map<String, Object> parameters = serviceCall.getParameters();
 
-		// handle parameters to filter message
-		DriverManager driverManager = ((SmartSpaceGateway) this.gateway).getDriverManager();
-		if (parameters != null) {
-			listDrivers = driverManager.listDrivers((String) parameters.get(DRIVER_NAME_KEY),
-					this.gateway.getCurrentDevice().getName());
-		} else {
-			// In case no parameters informed, list all drivers
-			listDrivers = driverManager.listDrivers(null, this.gateway.getCurrentDevice().getName());
-		}
+        // handle parameters to filter message
+        DriverManager driverManager = ((SmartSpaceGateway) this.gateway).getDriverManager();
+        if (parameters != null) {
+            listDrivers = driverManager.listDrivers((String) parameters.get(DRIVER_NAME_KEY),
+                    this.gateway.getCurrentDevice().getName());
+        } else {
+            // In case no parameters informed, list all drivers
+            listDrivers = driverManager.listDrivers(null, this.gateway.getCurrentDevice().getName());
+        }
 
-		// If the current device is doing proxy, filter the list of drivers
-		if (((SmartSpaceGateway) this.gateway).getConnectivityManager().doProxying()) {
-			((SmartSpaceGateway) this.gateway).getConnectivityManager().filterDriversList(listDrivers);
-		}
+        // If the current device is doing proxy, filter the list of drivers
+        if (((SmartSpaceGateway) this.gateway).getConnectivityManager().doProxying()) {
+            ((SmartSpaceGateway) this.gateway).getConnectivityManager().filterDriversList(listDrivers);
+        }
 
-		// Converts the list of DriverData into Parameters
-		ObjectNode driversList = mapper.getNodeFactory().objectNode();
-		if (listDrivers != null && !listDrivers.isEmpty()) {
-			for (DriverData driverData : listDrivers)
-				driversList.set(driverData.getInstanceID(), mapper.valueToTree(driverData.getDriver()));
-		}
-		@SuppressWarnings("rawtypes")
-		Map responseData = new HashMap();
+        // Converts the list of DriverData into Parameters
+        final Map<String, Object> driversList = new HashMap<String, Object>();
+        if (listDrivers != null)
+            for (DriverData driverData : listDrivers)
+                driversList.put(driverData.getInstanceID(), driverData.getDriver());
+        serviceResponse.setResponseData(new HashMap<String, Object>() {{
+            put(DRIVER_LIST_KEY, driversList);
+        }});
+    }
 
-		responseData.put(DRIVER_LIST_KEY, driversList);
+    /**
+     * Service responsible for authenticating a device. This Service can be
+     * called multiple times for a authentication process with multiple steps.
+     * The authentication algorithm is determined by the parameter
+     * 'securityType'.
+     */
+    public void authenticate(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        String securityType = (String) serviceCall.getParameters().get(SECURITY_TYPE_KEY);
 
-		serviceResponse.setResponseData(responseData);
-	}
+        // find the Authentication handler responsible for the requested
+        // securityType
+        AuthenticationHandler ah = ((SmartSpaceGateway) this.gateway).getSecurityManager()
+                .getAuthenticationHandler(securityType);
 
-	/**
-	 * Service responsible for authenticating a device. This Service can be
-	 * called multiple times for a authentication process with multiple steps.
-	 * The authentication algorithm is determined by the parameter
-	 * 'securityType'.
-	 */
-	public void authenticate(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        // delegate the authentication process to the AuthenticationHandler
+        // responsible
+        if (ah != null) {
+            ah.authenticate(serviceCall, serviceResponse, messageContext);
+        } else {
+            serviceResponse.setError("No AuthenticationHandler found for the security type : '" + securityType + "' .");
+        }
+    }
 
-		String securityType = (String) serviceCall.getParameters().get(SECURITY_TYPE_KEY);
+    /**
+     * This method is responsible for creating a mutual knowledge of two device
+     * about it's basic informations. This information must be informed in the
+     * parameter 'device'(<code>UpDevice</code>) by the caller device and will
+     * be returned in the same parameter with the information of the called
+     * device.
+     */
+    @SuppressWarnings("unchecked")
+    public void handshake(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        SmartSpaceGateway gtw = (SmartSpaceGateway) this.gateway;
+        DeviceManager deviceManager = gtw.getDeviceManager();
 
-		// find the Authentication handler responsible for the requested
-		// securityType
-		AuthenticationHandler ah = ((SmartSpaceGateway) this.gateway).getSecurityManager()
-				.getAuthenticationHandler(securityType);
+        // Get and Convert the UpDevice Parameter
+        Object deviceParameter = serviceCall.getParameter(DEVICE_KEY);
+        if (deviceParameter == null) {
+            serviceResponse.setError("No 'device' parameter informed.");
+            return;
+        }
+        try {
+            UpDevice device = deviceParameter instanceof String ?
+                    mapper.readValue((String) deviceParameter, UpDevice.class) :
+                    mapper.convertValue(deviceParameter, UpDevice.class);
+            // TODO : DeviceDriver : validate if the device doing the handshake
+            // is the same that is in the parameter
+            deviceManager.registerDevice(device);
+            serviceResponse.addParameter(DEVICE_KEY, mapper.valueToTree(gateway.getCurrentDevice()));
+            Response driversResponse = gateway.callService(device, new Call("uos.DeviceDriver", "listDrivers"));
+            Object driverList = driversResponse.getResponseData("driverList");
+            if (driverList != null) {
+                JavaType mapType = mapper.getTypeFactory().constructParametrizedType(Map.class, Map.class, String.class, UpDriver.class);
+                Map<String, UpDriver> driverMap = mapper.convertValue(driverList, mapType);
+                // TODO: this is duplicated with DeviceManager.registerRemoteDriverInstances
+                for (Map.Entry<String, UpDriver> entry : driverMap.entrySet()) {
+                    DriverModel driverModel = new DriverModel(entry.getKey(), entry.getValue(), device.getName());
+                    gtw.getDriverManager().insert(driverModel);
+                }
+            }
+        } catch (Exception e) {
+            serviceResponse.setError(e.getMessage());
+            logger.log(Level.SEVERE, "Problems on handshake", e);
+        }
+    }
 
-		// delegate the authentication process to the AuthenticationHandler
-		// responsible
-		if (ah != null) {
-			ah.authenticate(serviceCall, serviceResponse, messageContext);
-		} else {
-			serviceResponse.setError("No AuthenticationHandler found for the security type : '" + securityType + "' .");
-		}
+    /**
+     * This method is responsible for informing that the caller device is
+     * leaving the smart-space, so all its data must be removed.
+     */
+    public void goodbye(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        ((SmartSpaceGateway) gateway).getDeviceManager().deviceLeft(messageContext.getCallerNetworkDevice());
+    }
 
-	}
+    /**
+     * This method is responsible for informing the unknown equivalent driverss.
+     */
+    public void tellEquivalentDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        try {
 
-	/**
-	 * This method is responsible for creating a mutual knowledge of two device
-	 * about it's basic informations. This information must be informed in the
-	 * parameter 'device'(<code>UpDevice</code>) by the caller device and will
-	 * be returned in the same parameter with the information of the called
-	 * device.
-	 */
-	@SuppressWarnings("unchecked")
-	public void handshake(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		SmartSpaceGateway gtw = (SmartSpaceGateway) this.gateway;
-		DeviceManager deviceManager = gtw.getDeviceManager();
+            String equivalentDrivers = (String) serviceCall.getParameter(DRIVERS_NAME_KEY);
+            ArrayNode equivalentDriversJson = (ArrayNode) mapper.readTree(equivalentDrivers);
+            ArrayNode jsonList = mapper.getNodeFactory().arrayNode();
+            Map<String, Object> responseData = new HashMap<String, Object>();
+            for (int i = 0; i < equivalentDriversJson.size(); ++i) {
+                String equivalentDriver = equivalentDriversJson.get(i).asText();
+                UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
+                        .getDriverFromEquivalanceTree(equivalentDriver);
+                if (driver != null) {
+                    addToEquivalanceList(jsonList, driver);
+                }
+            }
+            responseData.put(INTERFACES_KEY, jsonList.toString());
+            serviceResponse.setResponseData(responseData);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Problems on equivalent drivers.", e);
+        }
+    }
 
-		// Get and Convert the UpDevice Parameter
-		String deviceParameter = (String) serviceCall.getParameterString(DEVICE_KEY);
-		if (deviceParameter == null) {
-			serviceResponse.setError("No 'device' parameter informed.");
-			return;
-		}
-		try {
-			UpDevice device = mapper.readValue(deviceParameter, UpDevice.class);
-			// TODO : DeviceDriver : validate if the device doing the handshake
-			// is the same that is in the parameter
-			deviceManager.registerDevice(device);
-			serviceResponse.addParameter(DEVICE_KEY, mapper.valueToTree(gateway.getCurrentDevice()));
-			Response driversResponse = gateway.callService(device, new Call("uos.DeviceDriver", "listDrivers"));
-			Object driverList = driversResponse.getResponseData("driverList");
-			if (driverList != null) {
-				Map<String, Object> driverMap = mapper.readValue(driverList.toString(), Map.class);
-				// TODO: this is duplicated with
-				// DeviceManager.registerRemoteDriverInstances
-				for (String id : driverMap.keySet()) {
-					UpDriver upDriver = mapper.readValue(mapper.writeValueAsString(driverMap.get(id)), UpDriver.class);
-					DriverModel driverModel = new DriverModel(id, upDriver, device.getName());
-					gtw.getDriverManager().insert(driverModel);
-				}
-			}
-		} catch (Exception e) {
-			serviceResponse.setError(e.getMessage());
-			logger.log(Level.SEVERE, "Problems on handshake", e);
-		}
-	}
-
-	/**
-	 * This method is responsible for informing that the caller device is
-	 * leaving the smart-space, so all its data must be removed.
-	 */
-	public void goodbye(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		((SmartSpaceGateway) gateway).getDeviceManager().deviceLeft(messageContext.getCallerNetworkDevice());
-	}
-
-	/**
-	 * This method is responsible for informing the unknown equivalent driverss.
-	 */
-	public void tellEquivalentDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		try {
-
-			String equivalentDrivers = (String) serviceCall.getParameter(DRIVERS_NAME_KEY);
-			ArrayNode equivalentDriversJson = (ArrayNode) mapper.readTree(equivalentDrivers);
-			ArrayNode jsonList = mapper.getNodeFactory().arrayNode();
-			Map<String, Object> responseData = new HashMap<String, Object>();
-			for (int i = 0; i < equivalentDriversJson.size(); ++i) {
-				String equivalentDriver = equivalentDriversJson.get(i).asText();
-				UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
-						.getDriverFromEquivalanceTree(equivalentDriver);
-				if (driver != null) {
-					addToEquivalanceList(jsonList, driver);
-				}
-			}
-			responseData.put(INTERFACES_KEY, jsonList.toString());
-			serviceResponse.setResponseData(responseData);
-		} catch (IOException e) {
-			logger.log(Level.SEVERE, "Problems on equivalent drivers.", e);
-		}
-	}
-
-	private void addToEquivalanceList(ArrayNode jsonList, UpDriver upDriver) {
-		List<String> equivalentDrivers = upDriver.getEquivalentDrivers();
-		if (equivalentDrivers != null) {
-			for (String equivalentDriver : equivalentDrivers) {
-				UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
-						.getDriverFromEquivalanceTree(equivalentDriver);
-				if (driver != null) {
-					addToEquivalanceList(jsonList, driver);
-				}
-			}
-		}
-		jsonList.add(mapper.valueToTree(upDriver));
-	}
+    private void addToEquivalanceList(ArrayNode jsonList, UpDriver upDriver) {
+        List<String> equivalentDrivers = upDriver.getEquivalentDrivers();
+        if (equivalentDrivers != null) {
+            for (String equivalentDriver : equivalentDrivers) {
+                UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
+                        .getDriverFromEquivalanceTree(equivalentDriver);
+                if (driver != null) {
+                    addToEquivalanceList(jsonList, driver);
+                }
+            }
+        }
+        jsonList.add(mapper.valueToTree(upDriver));
+    }
 
 }

--- a/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
+++ b/src/org/unbiquitous/uos/core/driver/DeviceDriver.java
@@ -1,12 +1,8 @@
 package org.unbiquitous.uos.core.driver;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.unbiquitous.uos.core.AuthenticationHandler;
 import org.unbiquitous.uos.core.InitialProperties;
 import org.unbiquitous.uos.core.UOSLogging;
@@ -24,218 +20,213 @@ import org.unbiquitous.uos.core.messageEngine.dataType.UpService;
 import org.unbiquitous.uos.core.messageEngine.messages.Call;
 import org.unbiquitous.uos.core.messageEngine.messages.Response;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Driver responsible for providing information about the device.
- * 
- * @author Fabricio Nogueira Buzeto
  *
+ * @author Fabricio Nogueira Buzeto
  */
 public class DeviceDriver implements UosDriver {
-	private static Logger logger = UOSLogging.getLogger();
-	private static final ObjectMapper mapper = new ObjectMapper();
+    private static Logger logger = UOSLogging.getLogger();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-	private static final String DEVICE_KEY = "device";
-	private static final String SECURITY_TYPE_KEY = "securityType";
-	private static final String DRIVER_LIST_KEY = "driverList";
-	private static final String DRIVER_NAME_KEY = "driverName";
-	private static final String INTERFACES_KEY = "interfaces";
-	private static final String DRIVERS_NAME_KEY = "driversName";
+    private static final String DEVICE_KEY = "device";
+    private static final String SECURITY_TYPE_KEY = "securityType";
+    private static final String DRIVER_LIST_KEY = "driverList";
+    private static final String DRIVER_NAME_KEY = "driverName";
+    private static final String INTERFACES_KEY = "interfaces";
+    private static final String DRIVERS_NAME_KEY = "driversName";
 
-	private Gateway gateway;
-	private final UpDriver driver;
+    private Gateway gateway;
+    private final UpDriver driver;
 
-	public DeviceDriver() {
-		driver = new UpDriver("uos.DeviceDriver");
+    public DeviceDriver() {
+        driver = new UpDriver("uos.DeviceDriver");
 
-		driver.addService("listDrivers").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.OPTIONAL);
+        driver.addService("listDrivers").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.OPTIONAL);
 
-		driver.addService("authenticate").addParameter(SECURITY_TYPE_KEY, UpService.ParameterType.MANDATORY);
+        driver.addService("authenticate").addParameter(SECURITY_TYPE_KEY, UpService.ParameterType.MANDATORY);
 
-		driver.addService("goodbye");
+        driver.addService("goodbye");
 
-		driver.addService("handshake").addParameter(DEVICE_KEY, UpService.ParameterType.MANDATORY);
+        driver.addService("handshake").addParameter(DEVICE_KEY, UpService.ParameterType.MANDATORY);
 
-		driver.addService("tellEquivalentDriver").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.MANDATORY);
-	}
+        driver.addService("tellEquivalentDriver").addParameter(DRIVER_NAME_KEY, UpService.ParameterType.MANDATORY);
+    }
 
-	@Override
-	public UpDriver getDriver() {
-		return driver;
-	}
+    @Override
+    public UpDriver getDriver() {
+        return driver;
+    }
 
-	@Override
-	public void init(Gateway gateway, InitialProperties properties, String instanceId) {
-		this.gateway = gateway;
-	}
+    @Override
+    public void init(Gateway gateway, InitialProperties properties, String instanceId) {
+        this.gateway = gateway;
+    }
 
-	@Override
-	public void destroy() {
-	}
+    @Override
+    public void destroy() {
+    }
 
-	@Override
-	public List<UpDriver> getParent() {
-		return null;
-	}
+    @Override
+    public List<UpDriver> getParent() {
+        return null;
+    }
 
-	/**
-	 * Service responsible for retrieving the list of Driver Instances present
-	 * in the underlying device. This listing service can have its result
-	 * filtered with the use of the parameters 'serviceName' or 'driverName'. It
-	 * responds in a single responseMap within the parameter 'driverList'
-	 */
-	@SuppressWarnings("unchecked")
-	public void listDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		logger.info("Handling DeviceDriverImpl#listDrivers service");
+    /**
+     * Service responsible for retrieving the list of Driver Instances present
+     * in the underlying device. This listing service can have its result
+     * filtered with the use of the parameters 'serviceName' or 'driverName'. It
+     * responds in a single responseMap within the parameter 'driverList'
+     */
+    @SuppressWarnings("unchecked")
+    public void listDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        logger.info("Handling DeviceDriverImpl#listDrivers service");
 
-		List<DriverData> listDrivers = null;
+        List<DriverData> listDrivers = null;
 
-		Map<String, Object> parameters = serviceCall.getParameters();
+        Map<String, Object> parameters = serviceCall.getParameters();
 
-		// handle parameters to filter message
-		DriverManager driverManager = ((SmartSpaceGateway) this.gateway).getDriverManager();
-		if (parameters != null) {
-			listDrivers = driverManager.listDrivers((String) parameters.get(DRIVER_NAME_KEY),
-					this.gateway.getCurrentDevice().getName());
-		} else {
-			// In case no parameters informed, list all drivers
-			listDrivers = driverManager.listDrivers(null, this.gateway.getCurrentDevice().getName());
-		}
+        // handle parameters to filter message
+        DriverManager driverManager = ((SmartSpaceGateway) this.gateway).getDriverManager();
+        if (parameters != null) {
+            listDrivers = driverManager.listDrivers((String) parameters.get(DRIVER_NAME_KEY),
+                    this.gateway.getCurrentDevice().getName());
+        } else {
+            // In case no parameters informed, list all drivers
+            listDrivers = driverManager.listDrivers(null, this.gateway.getCurrentDevice().getName());
+        }
 
-		// If the current device is doing proxy, filter the list of drivers
-		if (((SmartSpaceGateway) this.gateway).getConnectivityManager().doProxying()) {
-			((SmartSpaceGateway) this.gateway).getConnectivityManager().filterDriversList(listDrivers);
-		}
+        // If the current device is doing proxy, filter the list of drivers
+        if (((SmartSpaceGateway) this.gateway).getConnectivityManager().doProxying()) {
+            ((SmartSpaceGateway) this.gateway).getConnectivityManager().filterDriversList(listDrivers);
+        }
 
-		// Converts the list of DriverData into Parameters
-		ObjectNode driversList = mapper.getNodeFactory().objectNode();
-		if (listDrivers != null && !listDrivers.isEmpty()) {
-			for (DriverData driverData : listDrivers)
-				driversList.set(driverData.getInstanceID(), mapper.valueToTree(driverData.getDriver()));
-		}
-		@SuppressWarnings("rawtypes")
-		Map responseData = new HashMap();
+        // Converts the list of DriverData into Parameters
+        final Map<String, Object> driversList = new HashMap<String, Object>();
+        if (listDrivers != null)
+            for (DriverData driverData : listDrivers)
+                driversList.put(driverData.getInstanceID(), driverData.getDriver());
+        serviceResponse.setResponseData(new HashMap<String, Object>() {{
+            put(DRIVER_LIST_KEY, driversList);
+        }});
+    }
 
-		responseData.put(DRIVER_LIST_KEY, driversList);
+    /**
+     * Service responsible for authenticating a device. This Service can be
+     * called multiple times for a authentication process with multiple steps.
+     * The authentication algorithm is determined by the parameter
+     * 'securityType'.
+     */
+    public void authenticate(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        String securityType = (String) serviceCall.getParameters().get(SECURITY_TYPE_KEY);
 
-		serviceResponse.setResponseData(responseData);
-	}
+        // find the Authentication handler responsible for the requested
+        // securityType
+        AuthenticationHandler ah = ((SmartSpaceGateway) this.gateway).getSecurityManager()
+                .getAuthenticationHandler(securityType);
 
-	/**
-	 * Service responsible for authenticating a device. This Service can be
-	 * called multiple times for a authentication process with multiple steps.
-	 * The authentication algorithm is determined by the parameter
-	 * 'securityType'.
-	 */
-	public void authenticate(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        // delegate the authentication process to the AuthenticationHandler
+        // responsible
+        if (ah != null) {
+            ah.authenticate(serviceCall, serviceResponse, messageContext);
+        } else {
+            serviceResponse.setError("No AuthenticationHandler found for the security type : '" + securityType + "' .");
+        }
+    }
 
-		String securityType = (String) serviceCall.getParameters().get(SECURITY_TYPE_KEY);
+    /**
+     * This method is responsible for creating a mutual knowledge of two device
+     * about it's basic informations. This information must be informed in the
+     * parameter 'device'(<code>UpDevice</code>) by the caller device and will
+     * be returned in the same parameter with the information of the called
+     * device.
+     */
+    @SuppressWarnings("unchecked")
+    public void handshake(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        SmartSpaceGateway gtw = (SmartSpaceGateway) this.gateway;
+        DeviceManager deviceManager = gtw.getDeviceManager();
 
-		// find the Authentication handler responsible for the requested
-		// securityType
-		AuthenticationHandler ah = ((SmartSpaceGateway) this.gateway).getSecurityManager()
-				.getAuthenticationHandler(securityType);
+        // Get and Convert the UpDevice Parameter
+        String deviceParameter = (String) serviceCall.getParameterString(DEVICE_KEY);
+        if (deviceParameter == null) {
+            serviceResponse.setError("No 'device' parameter informed.");
+            return;
+        }
+        try {
+            UpDevice device = mapper.readValue(deviceParameter, UpDevice.class);
+            // TODO : DeviceDriver : validate if the device doing the handshake
+            // is the same that is in the parameter
+            deviceManager.registerDevice(device);
+            serviceResponse.addParameter(DEVICE_KEY, mapper.valueToTree(gateway.getCurrentDevice()));
+            Response driversResponse = gateway.callService(device, new Call("uos.DeviceDriver", "listDrivers"));
+            Object driverList = driversResponse.getResponseData("driverList");
+            if (driverList != null) {
+                JavaType mapType = mapper.getTypeFactory().constructParametrizedType(Map.class, Map.class, String.class, UpDriver.class);
+                Map<String, UpDriver> driverMap = mapper.convertValue(driverList, mapType);
+                // TODO: this is duplicated with DeviceManager.registerRemoteDriverInstances
+                for (Map.Entry<String, UpDriver> entry : driverMap.entrySet()) {
+                    DriverModel driverModel = new DriverModel(entry.getKey(), entry.getValue(), device.getName());
+                    gtw.getDriverManager().insert(driverModel);
+                }
+            }
+        } catch (Exception e) {
+            serviceResponse.setError(e.getMessage());
+            logger.log(Level.SEVERE, "Problems on handshake", e);
+        }
+    }
 
-		// delegate the authentication process to the AuthenticationHandler
-		// responsible
-		if (ah != null) {
-			ah.authenticate(serviceCall, serviceResponse, messageContext);
-		} else {
-			serviceResponse.setError("No AuthenticationHandler found for the security type : '" + securityType + "' .");
-		}
+    /**
+     * This method is responsible for informing that the caller device is
+     * leaving the smart-space, so all its data must be removed.
+     */
+    public void goodbye(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        ((SmartSpaceGateway) gateway).getDeviceManager().deviceLeft(messageContext.getCallerNetworkDevice());
+    }
 
-	}
+    /**
+     * This method is responsible for informing the unknown equivalent driverss.
+     */
+    public void tellEquivalentDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
+        try {
 
-	/**
-	 * This method is responsible for creating a mutual knowledge of two device
-	 * about it's basic informations. This information must be informed in the
-	 * parameter 'device'(<code>UpDevice</code>) by the caller device and will
-	 * be returned in the same parameter with the information of the called
-	 * device.
-	 */
-	@SuppressWarnings("unchecked")
-	public void handshake(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		SmartSpaceGateway gtw = (SmartSpaceGateway) this.gateway;
-		DeviceManager deviceManager = gtw.getDeviceManager();
+            String equivalentDrivers = (String) serviceCall.getParameter(DRIVERS_NAME_KEY);
+            ArrayNode equivalentDriversJson = (ArrayNode) mapper.readTree(equivalentDrivers);
+            ArrayNode jsonList = mapper.getNodeFactory().arrayNode();
+            Map<String, Object> responseData = new HashMap<String, Object>();
+            for (int i = 0; i < equivalentDriversJson.size(); ++i) {
+                String equivalentDriver = equivalentDriversJson.get(i).asText();
+                UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
+                        .getDriverFromEquivalanceTree(equivalentDriver);
+                if (driver != null) {
+                    addToEquivalanceList(jsonList, driver);
+                }
+            }
+            responseData.put(INTERFACES_KEY, jsonList.toString());
+            serviceResponse.setResponseData(responseData);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Problems on equivalent drivers.", e);
+        }
+    }
 
-		// Get and Convert the UpDevice Parameter
-		String deviceParameter = (String) serviceCall.getParameterString(DEVICE_KEY);
-		if (deviceParameter == null) {
-			serviceResponse.setError("No 'device' parameter informed.");
-			return;
-		}
-		try {
-			UpDevice device = mapper.readValue(deviceParameter, UpDevice.class);
-			// TODO : DeviceDriver : validate if the device doing the handshake
-			// is the same that is in the parameter
-			deviceManager.registerDevice(device);
-			serviceResponse.addParameter(DEVICE_KEY, mapper.valueToTree(gateway.getCurrentDevice()));
-			Response driversResponse = gateway.callService(device, new Call("uos.DeviceDriver", "listDrivers"));
-			Object driverList = driversResponse.getResponseData("driverList");
-			if (driverList != null) {
-				Map<String, Object> driverMap = mapper.readValue(driverList.toString(), Map.class);
-				// TODO: this is duplicated with
-				// DeviceManager.registerRemoteDriverInstances
-				for (String id : driverMap.keySet()) {
-					UpDriver upDriver = mapper.readValue(mapper.writeValueAsString(driverMap.get(id)), UpDriver.class);
-					DriverModel driverModel = new DriverModel(id, upDriver, device.getName());
-					gtw.getDriverManager().insert(driverModel);
-				}
-			}
-		} catch (Exception e) {
-			serviceResponse.setError(e.getMessage());
-			logger.log(Level.SEVERE, "Problems on handshake", e);
-		}
-	}
-
-	/**
-	 * This method is responsible for informing that the caller device is
-	 * leaving the smart-space, so all its data must be removed.
-	 */
-	public void goodbye(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		((SmartSpaceGateway) gateway).getDeviceManager().deviceLeft(messageContext.getCallerNetworkDevice());
-	}
-
-	/**
-	 * This method is responsible for informing the unknown equivalent driverss.
-	 */
-	public void tellEquivalentDrivers(Call serviceCall, Response serviceResponse, CallContext messageContext) {
-		try {
-
-			String equivalentDrivers = (String) serviceCall.getParameter(DRIVERS_NAME_KEY);
-			ArrayNode equivalentDriversJson = (ArrayNode) mapper.readTree(equivalentDrivers);
-			ArrayNode jsonList = mapper.getNodeFactory().arrayNode();
-			Map<String, Object> responseData = new HashMap<String, Object>();
-			for (int i = 0; i < equivalentDriversJson.size(); ++i) {
-				String equivalentDriver = equivalentDriversJson.get(i).asText();
-				UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
-						.getDriverFromEquivalanceTree(equivalentDriver);
-				if (driver != null) {
-					addToEquivalanceList(jsonList, driver);
-				}
-			}
-			responseData.put(INTERFACES_KEY, jsonList.toString());
-			serviceResponse.setResponseData(responseData);
-		} catch (IOException e) {
-			logger.log(Level.SEVERE, "Problems on equivalent drivers.", e);
-		}
-	}
-
-	private void addToEquivalanceList(ArrayNode jsonList, UpDriver upDriver) {
-		List<String> equivalentDrivers = upDriver.getEquivalentDrivers();
-		if (equivalentDrivers != null) {
-			for (String equivalentDriver : equivalentDrivers) {
-				UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
-						.getDriverFromEquivalanceTree(equivalentDriver);
-				if (driver != null) {
-					addToEquivalanceList(jsonList, driver);
-				}
-			}
-		}
-		jsonList.add(mapper.valueToTree(upDriver));
-	}
+    private void addToEquivalanceList(ArrayNode jsonList, UpDriver upDriver) {
+        List<String> equivalentDrivers = upDriver.getEquivalentDrivers();
+        if (equivalentDrivers != null) {
+            for (String equivalentDriver : equivalentDrivers) {
+                UpDriver driver = ((SmartSpaceGateway) gateway).getDriverManager()
+                        .getDriverFromEquivalanceTree(equivalentDriver);
+                if (driver != null) {
+                    addToEquivalanceList(jsonList, driver);
+                }
+            }
+        }
+        jsonList.add(mapper.valueToTree(upDriver));
+    }
 
 }

--- a/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
+++ b/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
@@ -1011,56 +1011,33 @@ public class DeviceManagerTest {
     @Test
     public void shouldNotThrowIfRemovingInvalidDeviceListener() throws Exception {
         deviceManager.removeDeviceListener(null);
-        deviceManager.removeDeviceListener(new DeviceListenerSwitch());
+        deviceManager.removeDeviceListener(mock(DeviceListener.class));
     }
 
     @Test
     public void shouldCallDeviceEnteredOnListenersIfRegisteredSuccessfully() throws Exception {
-        DeviceListenerSwitch listener = new DeviceListenerSwitch();
+        DeviceListener listener = mock(DeviceListener.class);
         deviceManager.addDeviceListener(listener);
         NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
         UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
                 .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
         when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
         deviceManager.deviceEntered(enteree);
-        assertEquals(1, listener.getEnteredCount(newGuy));
+        verify(listener, times(1)).deviceRegistered(newGuy);
     }
 
     @Test
     public void shouldCallDeviceLeftOnListenersIfKnownDeviceLeft() throws Exception {
-        DeviceListenerSwitch listener = new DeviceListenerSwitch();
+        DeviceListener listener = mock(DeviceListener.class);
         deviceManager.addDeviceListener(listener);
         NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
         UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
                 .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
         when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
         deviceManager.deviceEntered(enteree);
-        assertEquals(1, listener.getEnteredCount(newGuy));
+        verify(listener, times(1)).deviceRegistered(newGuy);
         deviceManager.deviceLeft(enteree);
-        assertEquals(1, listener.getEnteredCount(newGuy));
-        assertEquals(1, listener.getLeftCount(newGuy));
-    }
-
-    private static class DeviceListenerSwitch implements DeviceListener {
-        private Map<UpDevice, Integer> enteredDevices = new HashMap<UpDevice, Integer>();
-        private Map<UpDevice, Integer> leftDevices = new HashMap<UpDevice, Integer>();
-
-        @Override
-        public void deviceRegistered(UpDevice device) {
-            enteredDevices.put(device, getEnteredCount(device) + 1);
-        }
-
-        @Override
-        public void deviceUnregistered(UpDevice device) {
-            leftDevices.put(device, getLeftCount(device) + 1);
-        }
-
-        public int getEnteredCount(UpDevice device) {
-            return enteredDevices.containsKey(device) ? enteredDevices.get(device) : 0;
-        }
-
-        public int getLeftCount(UpDevice device) {
-            return leftDevices.containsKey(device) ? leftDevices.get(device) : 0;
-        }
+        verify(listener, times(1)).deviceUnregistered(newGuy);
+        verify(listener, times(1)).deviceRegistered(newGuy);
     }
 }

--- a/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
+++ b/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
@@ -1,24 +1,5 @@
 package org.unbiquitous.uos.core.deviceManager;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,13 +9,7 @@ import org.mockito.stubbing.Answer;
 import org.unbiquitous.uos.core.adaptabitilyEngine.Gateway;
 import org.unbiquitous.uos.core.adaptabitilyEngine.ServiceCallException;
 import org.unbiquitous.uos.core.connectivity.ConnectivityManager;
-import org.unbiquitous.uos.core.driverManager.DriverDao;
-import org.unbiquitous.uos.core.driverManager.DriverData;
-import org.unbiquitous.uos.core.driverManager.DriverManager;
-import org.unbiquitous.uos.core.driverManager.DriverManagerException;
-import org.unbiquitous.uos.core.driverManager.DriverModel;
-import org.unbiquitous.uos.core.driverManager.DriverNotFoundException;
-import org.unbiquitous.uos.core.driverManager.ReflectionServiceCaller;
+import org.unbiquitous.uos.core.driverManager.*;
 import org.unbiquitous.uos.core.driverManager.drivers.Pointer;
 import org.unbiquitous.uos.core.messageEngine.dataType.UpDevice;
 import org.unbiquitous.uos.core.messageEngine.dataType.UpDriver;
@@ -46,959 +21,994 @@ import org.unbiquitous.uos.core.network.connectionManager.ConnectionManagerContr
 import org.unbiquitous.uos.core.network.exceptions.NetworkException;
 import org.unbiquitous.uos.core.network.model.NetworkDevice;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.*;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
 
 public class DeviceManagerTest {
-
-	private final JsonNodeFactory factory = JsonNodeFactory.instance;
-	private final ObjectMapper mapper = new ObjectMapper();
-
-	private DeviceDao dao;
-	private DeviceManager deviceManager;
-	private DriverManager driverManager;
-	private UpDevice currentDevice;
-	private DriverDao driverDao;
-	private ConnectionManagerControlCenter connManager;
-	private Gateway gateway;
-	private ConnectivityManager proxier;
-
-	@Before
-	@SuppressWarnings("rawtypes")
-	public void setUp() {
-		dao = new DeviceDao(null);
-		driverDao = new DriverDao(null);
-		connManager = mock(ConnectionManagerControlCenter.class);
-		when(connManager.getHost(anyString())).thenAnswer(new Answer() {
-			@Override
-			public String answer(InvocationOnMock invocation) throws Throwable {
-				return (String) invocation.getArguments()[0];
-			}
-		});
-		gateway = mock(Gateway.class);
-		proxier = mock(ConnectivityManager.class);
-		currentDevice = new UpDevice("myDevice").addNetworkInterface("127.0.0.1:80", "Ethernet:TCP");
-		driverManager = new DriverManager(currentDevice, driverDao, dao, new ReflectionServiceCaller(null));
-		deviceManager = new DeviceManager(currentDevice, dao, driverDao, connManager, proxier, gateway, driverManager);
-	}
-
-	@After
-	public void tearDown() {
-		((DeviceDao) dao).clear();
-		driverDao.clear();
-	}
-
-	// public DeviceManager( UpDevice currentDevice,
-	// ConnectionManagerControlCenter connectionManagerControlCenter,
-	// ConnectivityManager connectivityManager, ResourceBundle resourceBundle,
-	// Gateway gateway) {
-	@Test
-	public void shouldSaveCurrentDeviceOnStart() {
-		List<UpDevice> devices = dao.list(null, null);
-		assertNotNull(devices);
-		assertEquals(1, devices.size());
-		assertEquals(currentDevice, devices.get(0));
-	}
-
-	// public void registerDevice(UpDevice device){
-	@Test
-	public void shouldSaveWhenRegistering() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		List<UpDevice> devices = dao.list(null, null);
-		assertNotNull(devices);
-		assertEquals(2, devices.size());
-		assertTrue(devices.contains(toRegister));
-	}
-
-	// public UpDevice retrieveDevice(String deviceName){
-	@Test
-	public void shouldRetrieveRegisteredDevice() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNotNull(deviceManager.retrieveDevice("aDevice"));
-		assertEquals(toRegister, deviceManager.retrieveDevice("aDevice"));
-	}
-
-	@Test
-	public void shouldNotRetrieveAUnRegisteredDevice() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNull(deviceManager.retrieveDevice("NotDevice"));
-	}
-
-	// public UpDevice retrieveDevice(String networkAdrress, String
-	// networkType){
-	@Test
-	public void shouldRetrieveARegisteredDeviceByNetworkAddress() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNotNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
-		assertEquals(toRegister, deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
-	}
-
-	@Test
-	public void shouldNotRetrieveAUnRegisteredDeviceByNetworkAddress() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNull(deviceManager.retrieveDevice("127.0.0.3", "Ethernet:TCP"));
-		assertNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:UDP"));
-	}
-
-	@Test
-	public void listsAllRegisteredDevices() {
-		UpDevice first = new UpDevice("firstDevice").addNetworkInterface("127.0.0.1", "Ethernet:TCP");
-		deviceManager.registerDevice(first);
-		UpDevice second = new UpDevice("secondDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(second);
-		assertThat(deviceManager.listDevices()).containsOnly(currentDevice, first, second);
-	}
-
-	// TODO: two devices with the same name == trouble
-
-	@Test
-	public void shouldRetrieveMultipleInstancesByDriverName() throws DriverManagerException, DriverNotFoundException {
-		UpDriver driver = new UpDriver("d1");
-		UpDevice myPhone = new UpDevice("my.Phone");
-		deviceManager.registerDevice(myPhone);
-		driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
-		driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		driverManager.insert(new DriverModel("id3", new UpDriver("d3"), "my.tablet"));
-		List<DriverData> list = driverManager.listDrivers("d1", null);
-		assertNotNull(list);
-		assertEquals(2, list.size());
-		assertEquals("id1", list.get(0).getInstanceID());
-		assertEquals(myPhone, list.get(0).getDevice());
-		assertEquals("id2", list.get(1).getInstanceID());
-		assertEquals(currentDevice, list.get(1).getDevice());
-	}
-
-	@Test
-	public void shouldRetrieveMultipleInstancesByDeviceName() throws DriverManagerException, DriverNotFoundException {
-		UpDriver driver = new UpDriver("d1");
-		driver.addService("s1").addParameter("p1", ParameterType.MANDATORY);
-		UpDriver driverD3 = new UpDriver("d3");
-		driverD3.addEvent("e1");
-		UpDevice myPhone = new UpDevice("my.Phone");
-		deviceManager.registerDevice(myPhone);
-		driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
-		driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		driverManager.insert(new DriverModel("id3", driverD3, "my.Phone"));
-		List<DriverData> list = driverManager.listDrivers(null, "my.Phone");
-		assertNotNull(list);
-		assertEquals(2, list.size());
-		assertEquals("id1", list.get(0).getInstanceID());
-		assertEquals(myPhone, list.get(0).getDevice());
-		assertEquals(driver, list.get(0).getDriver());
-		assertEquals("id3", list.get(1).getInstanceID());
-		assertEquals(myPhone, list.get(1).getDevice());
-		assertEquals(driverD3, list.get(1).getDriver());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceIsAlreadyKnownShouldDoNothing() throws Exception {
-		deviceManager.registerDevice(new UpDevice("IShouldKnow").addNetworkInterface("ADDR_KNOWN", "UNEXISTANT"));
-		assertEquals(2, dao.list().size());
-		when(connManager.getHost(eq("ADDR_KNOWN"))).thenReturn("ADDR_KNOWN");
-		NetworkDevice enteree = mock(NetworkDevice.class);
-		when(enteree.getNetworkDeviceName()).thenReturn("ADDR_KNOWN");
-		when(enteree.getNetworkDeviceType()).thenReturn("UNEXISTANT");
-		deviceManager.deviceEntered(enteree);
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(2, dao.list().size());
-	}
-
-	// null device or device data (addr and type)
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceIsNullShouldDoNothing() throws Exception {
-		assertEquals(1, dao.list().size());
-		deviceManager.deviceEntered(null);
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceProvidesNoDatalShouldDoNothing() throws Exception {
-		assertEquals(1, dao.list().size());
-		deviceManager.deviceEntered(mock(NetworkDevice.class));
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(1, dao.list().size());
-	}
-
-	// if doesn't knows the device, call 'handshake' on him passing
-	// currentDevice information
-	// Then register the device on the database
-
-	@Test
-	public void IfDontKnowTheDeviceCallAHandshakeWithIt() throws Exception {
-		when(gateway.callService((UpDevice) anyObject(), (Call) anyObject()))
-				.thenReturn(new Response().addParameter("device", mapper.writeValueAsString(new UpDevice("The Guy"))));
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		deviceManager.deviceEntered(enteree);
-		ArgumentCaptor<Call> scCacther = ArgumentCaptor.forClass(Call.class);
-		verify(gateway, times(2)).callService(any(UpDevice.class), scCacther.capture());
-		Call parameter = scCacther.getAllValues().get(0);
-		assertEquals("handshake", parameter.getService());
-		assertEquals("uos.DeviceDriver", parameter.getDriver());
-		assertNull(parameter.getInstanceId());
-		assertNull(parameter.getSecurityType());
-		assertEquals(currentDevice.toString(), parameter.getParameter("device"));
-	}
-
-	@Test
-	public void IfTheHandShakeWorksRegisterTheReturnedDevice() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheHandShakeHappensTwiceDoNothing() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheSecondHandShakeSucceedsRegisterDevice() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		deviceManager.deviceEntered(enteree);
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_NoResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(null);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_NoData() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(new Response());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_ErrorOnResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		Response error = new Response();
-		error.setError("Just Kidding");
-		when(gatewayHandshakeCall()).thenReturn(error);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_Exception() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenThrow(new RuntimeException());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	// if doesn't knows the device, call 'listDrivers'
-	// Then register the driver instances on the database
-
-	@Test
-	public void IfDontKnowTheDeviceCallListDriversOnIt() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		deviceManager.deviceEntered(enteree);
-		Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
-		verify(gateway, times(1)).callService(any(UpDevice.class), eq(listDrivers));
-	}
-
-	@Test
-	public void AfterListingTheDriverTheyMustBeRegistered() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
-				ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
-		deviceManager.deviceEntered(enteree);
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(2, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-		assertEquals("id2", newGuyDrivers.get(1).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToInterfaceValidationError() throws ServiceCallException, IOException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-
-		equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		UpService service = new UpService(Pointer.MOVE_EVENT);
-		service.addParameter(Pointer.AXIS_X, ParameterType.MANDATORY);
-		service.addParameter(Pointer.AXIS_Y, ParameterType.MANDATORY);
-		equivalentDriver.addEvent(service);
-
-		UpService register = new UpService("registerListener").addParameter("eventKey", ParameterType.MANDATORY);
-		equivalentDriver.addService(register);
-
-		UpService unregister = new UpService("unregisterListener").addParameter("eventKey", ParameterType.OPTIONAL);
-		equivalentDriver.addService(unregister);
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToNullEquivalentDriverResponse() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		when(gatewayTellEquivalentDriverCall()).thenReturn(null);
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToInterfaceNotProvided() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		when(gatewayTellEquivalentDriverCall()).thenReturn(new Response().addParameter("interfaces", null));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToWrongJSONObject() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		when(gatewayListDriversCall())
-				.thenReturn(new Response().addParameter("driverList", new String("wrongJSONObject")));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToMissingServer() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToEquivalentDriverInterfaceValidationError() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverWithEquivalentDriverNotInformed() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-		equivalentDriver.addEquivalentDrivers("notInformedEquivalentDriver");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	public void shouldNotRegisterADriverWithTwoEquivalentDriversNotInformed() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver1");
-		dummy.addEquivalentDrivers("equivalentDriver2");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver1 = new UpDriver("equivalentDriver1");
-		equivalentDriver1.addService("s1");
-		equivalentDriver1.addEquivalentDrivers("notInformedEquivalentDriver1");
-		UpDriver equivalentDriver2 = new UpDriver("equivalentDriver2");
-		equivalentDriver2.addEquivalentDrivers("notInformedEquivalentDriver2");
-		equivalentDriver2.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver1));
-		jsonList.add(mapper.valueToTree(equivalentDriver2));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldRegisterADriverWithUnknownEquivalentDriver() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(1, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriver() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-
-		UpDriver dummy1 = new UpDriver("DummyDriver1");
-		dummy1.addService("s1");
-		dummy1.addEquivalentDrivers("equivalentDriver");
-
-		UpDriver dummy2 = new UpDriver("DummyDriver2");
-		dummy2.addService("s1");
-		dummy2.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("iddummy1", mapper.valueToTree(dummy1));
-		driverList.set("iddummy2", mapper.valueToTree(dummy2));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		assertEquals(2, newGuyDrivers.size());
-		assertEquals("iddummy1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
-		assertEquals("iddummy2", newGuyDrivers.get(1).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
-	}
-
-	@Test
-	public void shouldRegisterADriverWithTwoLevelsOfUnknownEquivalentDrivers() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-		equivalentDriver.addEquivalentDrivers("equivalentToTheEquivalentDriver");
-
-		UpDriver equivalentToTheEquivalentDriver = new UpDriver("equivalentToTheEquivalentDriver");
-		equivalentToTheEquivalentDriver.addService("s1");
-
-		ArrayNode equivalentDrivers = factory.arrayNode();
-		equivalentDrivers.add(mapper.valueToTree(equivalentDriver));
-		equivalentDrivers.add(mapper.valueToTree(equivalentToTheEquivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", equivalentDrivers.toString()));
-
-		deviceManager.deviceEntered(enteree);
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		// verify(gatewayTellEquivalentDriverCall(), times(2));
-		assertEquals(1, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriverFromDifferentLevels()
-			throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-
-		UpDriver dummy1 = new UpDriver("D1");
-		dummy1.addService("s1");
-		dummy1.addEquivalentDrivers("D0");
-
-		UpDriver dummy2 = new UpDriver("D4");
-		dummy2.addService("s1");
-		dummy2.addEquivalentDrivers("D3");
-
-		driverList.set("iddummy1", mapper.valueToTree(dummy1));
-		driverList.set("iddummy2", mapper.valueToTree(dummy2));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver d0 = new UpDriver("D0");
-		d0.addService("s1");
-
-		UpDriver d2 = new UpDriver("D2");
-		d2.addService("s1");
-		d2.addEquivalentDrivers(d0.getName());
-
-		UpDriver d3 = new UpDriver("D3");
-		d3.addService("s1");
-		d3.addEquivalentDrivers(d2.getName());
-
-		jsonList.add(mapper.valueToTree(d3));
-		jsonList.add(mapper.valueToTree(d0));
-		jsonList.add(mapper.valueToTree(d2));
-
-		when(gatewayTellTwoEquivalentDrivers())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		// TODO: This
-		assertEquals(2, newGuyDrivers.size());
-		if (newGuyDrivers.get(0).id().equals("iddummy1")) {
-			assertEquals("iddummy1", newGuyDrivers.get(0).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
-			assertEquals("iddummy2", newGuyDrivers.get(1).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
-		} else {
-			assertEquals("iddummy2", newGuyDrivers.get(0).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy2));
-			assertEquals("iddummy1", newGuyDrivers.get(1).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy1));
-		}
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_NoResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenReturn(null);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_NoData() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenReturn(new Response());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	// FIXME: [B&M] Sempre passa! Como testar caso de erro?!
-	@Test
-	public void shouldNotHandshakeWithItsSelf() throws NetworkException, ServiceCallException {
-		NetworkDevice enteree = mock(NetworkDevice.class);
-
-		when(enteree.getNetworkDeviceName()).thenReturn("127.0.0.1:8080");
-		when(enteree.getNetworkDeviceType()).thenReturn("Ethernet:TCP");
-		when(connManager.getHost("127.0.0.1:8080")).thenReturn("127.0.0.1");
-		when(connManager.getHost("127.0.0.1:80")).thenReturn("127.0.0.1");
-		deviceManager.deviceEntered(enteree);
-		verify(gateway, never()).callService((UpDevice) any(), (Call) any());
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_ThrowingException() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenThrow(new RuntimeException());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	private NetworkDevice networkDevice(String address, String type) {
-		NetworkDevice enteree = mock(NetworkDevice.class);
-		when(enteree.getNetworkDeviceName()).thenReturn(address);
-		when(enteree.getNetworkDeviceType()).thenReturn(type);
-		return enteree;
-	}
-
-	private Response gatewayHandshakeCall() throws ServiceCallException {
-		Call handshake = new Call("uos.DeviceDriver", "handshake", null);
-		handshake.addParameter("device", currentDevice.toString());
-		return gateway.callService(any(UpDevice.class), eq(handshake));
-	}
-
-	private Response gatewayListDriversCall() throws ServiceCallException {
-		Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
-		return gateway.callService(any(UpDevice.class), eq(listDrivers));
-	}
-
-	private Response gatewayTellEquivalentDriverCall() throws ServiceCallException {
-		Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
-		ArrayNode equivalents = factory.arrayNode();
-		equivalents.add(factory.textNode("equivalentDriver"));
-		tellEquivalentDriver.addParameter("driversName", equivalents.toString());
-		return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
-	}
-
-	private Response gatewayTellTwoEquivalentDrivers() throws ServiceCallException {
-		Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
-		ArrayNode equivalents = factory.arrayNode();
-		equivalents.add(factory.textNode("D0"));
-		equivalents.add(factory.textNode("D3"));
-		tellEquivalentDriver.addParameter("driversName", equivalents.toString());
-		return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
-	}
-
-	// TODO: What about proxying
-	@Test
-	public void AfterListingIfProxyingIsEnabledRegisterIt() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response()
-					.addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString())
-		);
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1")
-			.addParameter("s1p1", ParameterType.MANDATORY)
-			.addParameter("s1p2", ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-		when(proxier.doProxying()).thenReturn(true);
-		deviceManager.deviceEntered(enteree);
-		ArgumentCaptor<UpDevice> deviceCatcher = ArgumentCaptor.forClass(UpDevice.class);
-		ArgumentCaptor<String> idCatcher = ArgumentCaptor.forClass(String.class);
-		verify(proxier, times(2)).registerProxyDriver(eq(dummy), deviceCatcher.capture(), idCatcher.capture());
-		assertEquals("A", deviceCatcher.getValue().getName());
-		assertEquals("id1", idCatcher.getAllValues().get(0));
-		assertEquals("id2", idCatcher.getAllValues().get(1));
-	}
-
-	@Test
-	public void AfterListingIfProxyingIsNotEnabledDoNothing() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
-				ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-		when(proxier.doProxying()).thenReturn(false);
-		deviceManager.deviceEntered(enteree);
-		verify(proxier, never()).registerProxyDriver(any(UpDriver.class), any(UpDevice.class), any(String.class));
-	}
-
-	// public void deviceLeft(NetworkDevice device) {
-	@Test
-	public void removeTheDeviceFromDatabaseOnLeft() throws Exception {
-		NetworkDevice leavingCard = networkDevice("ADDR_UNKNOWN_A", "UNEXISTANT");
-		UpDevice leavingGuy = upDevice("leavingMan", leavingCard);
-		when(connManager.getHost(eq(leavingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_A");
-		deviceManager.registerDevice(leavingGuy);
-
-		NetworkDevice stayingCard = networkDevice("ADDR_UNKNOWN_B", "UNEXISTANT");
-		UpDevice stayingGuy = upDevice("stayingMan", stayingCard);
-		when(connManager.getHost(eq(stayingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_B");
-		deviceManager.registerDevice(stayingGuy);
-
-		assertEquals(3, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id4", driver, stayingGuy.getName()));
-		assertEquals(4, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingCard);
-		assertEquals(2, dao.list().size());
-		assertEquals(1, driverDao.list().size());
-	}
-
-	private UpDevice upDevice(String name, NetworkDevice networkCard) {
-		return new UpDevice(name).addNetworkInterface(networkCard.getNetworkDeviceName(),
-				networkCard.getNetworkDeviceType());
-	}
-
-	@Test
-	public void doNothingWhenLeftingANullDevice() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice oldGuy = upDevice("OldMan", leavingGuy);
-		when(connManager.getHost(eq(leavingGuy.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN");
-		deviceManager.registerDevice(oldGuy);
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
-		assertEquals(3, driverDao.list().size());
-
-		deviceManager.deviceLeft(null);
-		assertEquals(2, dao.list().size());
-		assertEquals(3, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingADeviceWithNullData() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice oldGuy = upDevice("OldMan", leavingGuy);
-		deviceManager.registerDevice(oldGuy);
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
-		assertEquals(3, driverDao.list().size());
-
-		deviceManager.deviceLeft(mock(NetworkDevice.class));
-		assertEquals(2, dao.list().size());
-		assertEquals(3, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingAnUnkownDevice() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		assertEquals(1, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
-		driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		assertEquals(2, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingGuy);
-		assertEquals(1, dao.list().size());
-		assertEquals(2, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingAnUnkownDevicexxxx() throws Exception {
-		NetworkDevice knownCard = networkDevice("ADDR_KNOWN", "THIS_ONE");
-		UpDevice knownGuy = upDevice("OldMan", knownCard);
-		deviceManager.registerDevice(knownGuy);
-
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "THIS_ONE");
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
-		driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		assertEquals(2, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingGuy);
-		assertEquals(2, dao.list().size());
-		assertEquals(2, driverDao.list().size());
-	}
+    private DeviceDao dao;
+    private DeviceManager deviceManager;
+    private DriverManager driverManager;
+    private UpDevice currentDevice;
+    private DriverDao driverDao;
+    private ConnectionManagerControlCenter connManager;
+    private Gateway gateway;
+    private ConnectivityManager proxier;
+
+    @Before
+    @SuppressWarnings("rawtypes")
+    public void setUp() {
+        dao = new DeviceDao(null);
+        driverDao = new DriverDao(null);
+        connManager = mock(ConnectionManagerControlCenter.class);
+        when(connManager.getHost(anyString())).thenAnswer(new Answer() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return (String) invocation.getArguments()[0];
+            }
+        });
+        gateway = mock(Gateway.class);
+        proxier = mock(ConnectivityManager.class);
+        currentDevice = new UpDevice("myDevice").addNetworkInterface("127.0.0.1:80", "Ethernet:TCP");
+        driverManager = new DriverManager(currentDevice, driverDao, dao, new ReflectionServiceCaller(null));
+        deviceManager = new DeviceManager(currentDevice, dao, driverDao, connManager, proxier, gateway, driverManager);
+    }
+
+    @After
+    public void tearDown() {
+        ((DeviceDao) dao).clear();
+        driverDao.clear();
+    }
+
+    // public DeviceManager( UpDevice currentDevice,
+    // ConnectionManagerControlCenter connectionManagerControlCenter,
+    // ConnectivityManager connectivityManager, ResourceBundle resourceBundle,
+    // Gateway gateway) {
+    @Test
+    public void shouldSaveCurrentDeviceOnStart() {
+        List<UpDevice> devices = dao.list(null, null);
+        assertNotNull(devices);
+        assertEquals(1, devices.size());
+        assertEquals(currentDevice, devices.get(0));
+    }
+
+    // public void registerDevice(UpDevice device){
+    @Test
+    public void shouldSaveWhenRegistering() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        List<UpDevice> devices = dao.list(null, null);
+        assertNotNull(devices);
+        assertEquals(2, devices.size());
+        assertTrue(devices.contains(toRegister));
+    }
+
+    // public UpDevice retrieveDevice(String deviceName){
+    @Test
+    public void shouldRetrieveRegisteredDevice() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNotNull(deviceManager.retrieveDevice("aDevice"));
+        assertEquals(toRegister, deviceManager.retrieveDevice("aDevice"));
+    }
+
+    @Test
+    public void shouldNotRetrieveAUnRegisteredDevice() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNull(deviceManager.retrieveDevice("NotDevice"));
+    }
+
+    // public UpDevice retrieveDevice(String networkAdrress, String
+    // networkType){
+    @Test
+    public void shouldRetrieveARegisteredDeviceByNetworkAddress() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNotNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
+        assertEquals(toRegister, deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
+    }
+
+    @Test
+    public void shouldNotRetrieveAUnRegisteredDeviceByNetworkAddress() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNull(deviceManager.retrieveDevice("127.0.0.3", "Ethernet:TCP"));
+        assertNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:UDP"));
+    }
+
+    @Test
+    public void listsAllRegisteredDevices() {
+        UpDevice first = new UpDevice("firstDevice").addNetworkInterface("127.0.0.1", "Ethernet:TCP");
+        deviceManager.registerDevice(first);
+        UpDevice second = new UpDevice("secondDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(second);
+        assertThat(deviceManager.listDevices()).containsOnly(currentDevice, first, second);
+    }
+
+    // TODO: two devices with the same name == trouble
+
+    @Test
+    public void shouldRetrieveMultipleInstancesByDriverName() throws DriverManagerException, DriverNotFoundException {
+        UpDriver driver = new UpDriver("d1");
+        UpDevice myPhone = new UpDevice("my.Phone");
+        deviceManager.registerDevice(myPhone);
+        driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
+        driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        driverManager.insert(new DriverModel("id3", new UpDriver("d3"), "my.tablet"));
+        List<DriverData> list = driverManager.listDrivers("d1", null);
+        assertNotNull(list);
+        assertEquals(2, list.size());
+        assertEquals("id1", list.get(0).getInstanceID());
+        assertEquals(myPhone, list.get(0).getDevice());
+        assertEquals("id2", list.get(1).getInstanceID());
+        assertEquals(currentDevice, list.get(1).getDevice());
+    }
+
+    @Test
+    public void shouldRetrieveMultipleInstancesByDeviceName() throws DriverManagerException, DriverNotFoundException {
+        UpDriver driver = new UpDriver("d1");
+        driver.addService("s1").addParameter("p1", ParameterType.MANDATORY);
+        UpDriver driverD3 = new UpDriver("d3");
+        driverD3.addEvent("e1");
+        UpDevice myPhone = new UpDevice("my.Phone");
+        deviceManager.registerDevice(myPhone);
+        driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
+        driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        driverManager.insert(new DriverModel("id3", driverD3, "my.Phone"));
+        List<DriverData> list = driverManager.listDrivers(null, "my.Phone");
+        assertNotNull(list);
+        assertEquals(2, list.size());
+        assertEquals("id1", list.get(0).getInstanceID());
+        assertEquals(myPhone, list.get(0).getDevice());
+        assertEquals(driver, list.get(0).getDriver());
+        assertEquals("id3", list.get(1).getInstanceID());
+        assertEquals(myPhone, list.get(1).getDevice());
+        assertEquals(driverD3, list.get(1).getDriver());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceIsAlreadyKnownShouldDoNothing() throws Exception {
+        deviceManager.registerDevice(new UpDevice("IShouldKnow").addNetworkInterface("ADDR_KNOWN", "INEXISTENT"));
+        assertEquals(2, dao.list().size());
+        when(connManager.getHost(eq("ADDR_KNOWN"))).thenReturn("ADDR_KNOWN");
+        NetworkDevice enteree = mock(NetworkDevice.class);
+        when(enteree.getNetworkDeviceName()).thenReturn("ADDR_KNOWN");
+        when(enteree.getNetworkDeviceType()).thenReturn("INEXISTENT");
+        deviceManager.deviceEntered(enteree);
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(2, dao.list().size());
+    }
+
+    // null device or device data (addr and type)
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceIsNullShouldDoNothing() throws Exception {
+        assertEquals(1, dao.list().size());
+        deviceManager.deviceEntered(null);
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceProvidesNoDatalShouldDoNothing() throws Exception {
+        assertEquals(1, dao.list().size());
+        deviceManager.deviceEntered(mock(NetworkDevice.class));
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(1, dao.list().size());
+    }
+
+    // if doesn't knows the device, call 'handshake' on him passing
+    // currentDevice information
+    // Then register the device on the database
+
+    @Test
+    public void IfDontKnowTheDeviceCallAHandshakeWithIt() throws Exception {
+        when(gateway.callService((UpDevice) anyObject(), (Call) anyObject()))
+                .thenReturn(new Response().addParameter("device", new UpDevice("The Guy")));
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        deviceManager.deviceEntered(enteree);
+        ArgumentCaptor<Call> scCacther = ArgumentCaptor.forClass(Call.class);
+        verify(gateway, times(2)).callService(any(UpDevice.class), scCacther.capture());
+        Call parameter = scCacther.getAllValues().get(0);
+        assertEquals("handshake", parameter.getService());
+        assertEquals("uos.DeviceDriver", parameter.getDriver());
+        assertNull(parameter.getInstanceId());
+        assertNull(parameter.getSecurityType());
+        assertEquals(currentDevice, parameter.getParameter("device"));
+    }
+
+    @Test
+    public void IfTheHandShakeWorksRegisterTheReturnedDevice() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "INEXISTENT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheHandShakeHappensTwiceDoNothing() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "INEXISTENT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy));
+        deviceManager.deviceEntered(enteree);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheSecondHandShakeSucceedsRegisterDevice() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "INEXISTENT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        deviceManager.deviceEntered(enteree);
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_NoResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenReturn(null);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_NoData() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenReturn(new Response());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_ErrorOnResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        Response error = new Response();
+        error.setError("Just Kidding");
+        when(gatewayHandshakeCall()).thenReturn(error);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_Exception() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenThrow(new RuntimeException());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    // if doesn't knows the device, call 'listDrivers'
+    // Then register the driver instances on the database
+
+    @Test
+    public void IfDontKnowTheDeviceCallListDriversOnIt() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T")));
+        deviceManager.deviceEntered(enteree);
+        Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
+        verify(gateway, times(1)).callService(any(UpDevice.class), eq(listDrivers));
+    }
+
+    @Test
+    public void AfterListingTheDriverTheyMustBeRegistered() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall())
+                .thenReturn(new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T")));
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2", ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        map.put("id1", dummy);
+        map.put("id2", dummy);
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+        deviceManager.deviceEntered(enteree);
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(2, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(newGuyDrivers.get(0).driver()).isEqualTo(dummy);
+        assertEquals("id2", newGuyDrivers.get(1).id());
+        assertThat(newGuyDrivers.get(1).driver()).isEqualTo(dummy);
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToInterfaceValidationError() throws ServiceCallException, IOException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        List<UpDriver> list = new ArrayList<UpDriver>();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        UpService service = new UpService(Pointer.MOVE_EVENT);
+        service.addParameter(Pointer.AXIS_X, ParameterType.MANDATORY);
+        service.addParameter(Pointer.AXIS_Y, ParameterType.MANDATORY);
+        equivalentDriver.addEvent(service);
+
+        UpService register = new UpService("registerListener").addParameter("eventKey", ParameterType.MANDATORY);
+        equivalentDriver.addService(register);
+
+        UpService unregister = new UpService("unregisterListener").addParameter("eventKey", ParameterType.OPTIONAL);
+        equivalentDriver.addService(unregister);
+
+        list.add(equivalentDriver);
+
+        when(gatewayTellEquivalentDriverCall()).thenReturn(new Response().addParameter("interfaces", list));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToNullEquivalentDriverResponse() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        when(gatewayTellEquivalentDriverCall()).thenReturn(null);
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToInterfaceNotProvided() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        when(gatewayTellEquivalentDriverCall()).thenReturn(new Response().addParameter("interfaces", null));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToWrongJSONObject() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        when(gatewayListDriversCall())
+                .thenReturn(new Response().addParameter("driverList", new String("wrongJSONObject")));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToMissingServer() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToEquivalentDriverInterfaceValidationError() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        List<UpDriver> list = new ArrayList<UpDriver>();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
+        equivalentDriver.addService("s1");
+
+        list.add(equivalentDriver);
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", list));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverWithEquivalentDriverNotInformed() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        List<UpDriver> list = new ArrayList<UpDriver>();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+        equivalentDriver.addEquivalentDrivers("notInformedEquivalentDriver");
+
+        list.add(equivalentDriver);
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", list));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    public void shouldNotRegisterADriverWithTwoEquivalentDriversNotInformed() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver1");
+        dummy.addEquivalentDrivers("equivalentDriver2");
+
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        List<UpDriver> list = new ArrayList<UpDriver>();
+
+        UpDriver equivalentDriver1 = new UpDriver("equivalentDriver1");
+        equivalentDriver1.addService("s1");
+        equivalentDriver1.addEquivalentDrivers("notInformedEquivalentDriver1");
+        UpDriver equivalentDriver2 = new UpDriver("equivalentDriver2");
+        equivalentDriver2.addEquivalentDrivers("notInformedEquivalentDriver2");
+        equivalentDriver2.addService("s1");
+
+        list.add(equivalentDriver1);
+        list.add(equivalentDriver2);
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", list));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldRegisterADriverWithUnknownEquivalentDriver() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        List<UpDriver> list = new ArrayList<UpDriver>();
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+        list.add(equivalentDriver);
+
+        when(gatewayTellEquivalentDriverCall()).thenReturn(new Response().addParameter("interfaces", list));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(1, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(newGuyDrivers.get(0).driver()).isEqualTo(dummy);
+    }
+
+    @Test
+    public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriver() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+
+        UpDriver dummy1 = new UpDriver("DummyDriver1");
+        dummy1.addService("s1");
+        dummy1.addEquivalentDrivers("equivalentDriver");
+
+        UpDriver dummy2 = new UpDriver("DummyDriver2");
+        dummy2.addService("s1");
+        dummy2.addEquivalentDrivers("equivalentDriver");
+
+        map.put("iddummy1", dummy1);
+        map.put("iddummy2", dummy2);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        List<UpDriver> list = new ArrayList<UpDriver>();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+
+        list.add(equivalentDriver);
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", list));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        assertEquals(2, newGuyDrivers.size());
+        assertEquals("iddummy1", newGuyDrivers.get(0).id());
+        assertThat(newGuyDrivers.get(0).driver()).isEqualTo(dummy1);
+        assertEquals("iddummy2", newGuyDrivers.get(1).id());
+        assertThat(newGuyDrivers.get(1).driver()).isEqualTo(dummy2);
+    }
+
+    @Test
+    public void shouldRegisterADriverWithTwoLevelsOfUnknownEquivalentDrivers() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        map.put("id1", dummy);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+        equivalentDriver.addEquivalentDrivers("equivalentToTheEquivalentDriver");
+
+        UpDriver equivalentToTheEquivalentDriver = new UpDriver("equivalentToTheEquivalentDriver");
+        equivalentToTheEquivalentDriver.addService("s1");
+
+        List<UpDriver> equivalentDrivers = new ArrayList<UpDriver>();
+        equivalentDrivers.add(equivalentDriver);
+        equivalentDrivers.add(equivalentToTheEquivalentDriver);
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", equivalentDrivers));
+
+        deviceManager.deviceEntered(enteree);
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        // verify(gatewayTellEquivalentDriverCall(), times(2));
+        assertEquals(1, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(newGuyDrivers.get(0).driver()).isEqualTo(dummy);
+    }
+
+    @Test
+    public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriverFromDifferentLevels() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device));
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+
+        UpDriver dummy1 = new UpDriver("D1");
+        dummy1.addService("s1");
+        dummy1.addEquivalentDrivers("D0");
+
+        UpDriver dummy2 = new UpDriver("D4");
+        dummy2.addService("s1");
+        dummy2.addEquivalentDrivers("D3");
+
+        map.put("iddummy1", dummy1);
+        map.put("iddummy2", dummy2);
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+
+        List<UpDriver> list = new ArrayList<UpDriver>();
+
+        UpDriver d0 = new UpDriver("D0");
+        d0.addService("s1");
+
+        UpDriver d2 = new UpDriver("D2");
+        d2.addService("s1");
+        d2.addEquivalentDrivers(d0.getName());
+
+        UpDriver d3 = new UpDriver("D3");
+        d3.addService("s1");
+        d3.addEquivalentDrivers(d2.getName());
+
+        list.add(d3);
+        list.add(d0);
+        list.add(d2);
+
+        when(gatewayTellTwoEquivalentDrivers()).thenReturn(new Response().addParameter("interfaces", list));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        // TODO: This
+        assertEquals(2, newGuyDrivers.size());
+        if (newGuyDrivers.get(0).id().equals("iddummy1")) {
+            assertEquals("iddummy1", newGuyDrivers.get(0).id());
+            assertThat(newGuyDrivers.get(0).driver()).isEqualTo(dummy1);
+            assertEquals("iddummy2", newGuyDrivers.get(1).id());
+            assertThat(newGuyDrivers.get(1).driver()).isEqualTo(dummy2);
+        } else {
+            assertEquals("iddummy2", newGuyDrivers.get(0).id());
+            assertThat(newGuyDrivers.get(0).driver()).isEqualTo(dummy2);
+            assertEquals("iddummy1", newGuyDrivers.get(1).id());
+            assertThat(newGuyDrivers.get(1).driver()).isEqualTo(dummy1);
+        }
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_NoResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T")));
+        when(gatewayListDriversCall()).thenReturn(null);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_NoData() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T")));
+        when(gatewayListDriversCall()).thenReturn(new Response());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    // FIXME: [B&M] Sempre passa! Como testar caso de erro?!
+    @Test
+    public void shouldNotHandshakeWithItsSelf() throws NetworkException, ServiceCallException {
+        NetworkDevice enteree = mock(NetworkDevice.class);
+
+        when(enteree.getNetworkDeviceName()).thenReturn("127.0.0.1:8080");
+        when(enteree.getNetworkDeviceType()).thenReturn("Ethernet:TCP");
+        when(connManager.getHost("127.0.0.1:8080")).thenReturn("127.0.0.1");
+        when(connManager.getHost("127.0.0.1:80")).thenReturn("127.0.0.1");
+        deviceManager.deviceEntered(enteree);
+        verify(gateway, never()).callService((UpDevice) any(), (Call) any());
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_ThrowingException() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T")));
+        when(gatewayListDriversCall()).thenThrow(new RuntimeException());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    private NetworkDevice networkDevice(String address, String type) {
+        NetworkDevice enteree = mock(NetworkDevice.class);
+        when(enteree.getNetworkDeviceName()).thenReturn(address);
+        when(enteree.getNetworkDeviceType()).thenReturn(type);
+        return enteree;
+    }
+
+    private Response gatewayHandshakeCall() throws ServiceCallException {
+        Call handshake = new Call("uos.DeviceDriver", "handshake", null);
+        handshake.addParameter("device", currentDevice);
+        return gateway.callService(any(UpDevice.class), eq(handshake));
+    }
+
+    private Response gatewayListDriversCall() throws ServiceCallException {
+        Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
+        return gateway.callService(any(UpDevice.class), eq(listDrivers));
+    }
+
+    private Response gatewayTellEquivalentDriverCall() throws ServiceCallException {
+        Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
+        List<String> equivalents = new ArrayList<String>();
+        equivalents.add("equivalentDriver");
+        tellEquivalentDriver.addParameter("driversName", equivalents);
+        return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
+    }
+
+    private Response gatewayTellTwoEquivalentDrivers() throws ServiceCallException {
+        Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
+        List<String> equivalents = new ArrayList<String>();
+        equivalents.add("D0");
+        equivalents.add("D3");
+        tellEquivalentDriver.addParameter("driversName", equivalents);
+        return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
+    }
+
+    // TODO: What about proxying
+    @Test
+    public void AfterListingIfProxyingIsEnabledRegisterIt() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response()
+                        .addParameter("device", new UpDevice("A").addNetworkInterface("A", "T"))
+        );
+
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1")
+                .addParameter("s1p1", ParameterType.MANDATORY)
+                .addParameter("s1p2", ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        map.put("id1", dummy);
+        map.put("id2", dummy);
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+        when(proxier.doProxying()).thenReturn(true);
+        deviceManager.deviceEntered(enteree);
+        ArgumentCaptor<UpDevice> deviceCatcher = ArgumentCaptor.forClass(UpDevice.class);
+        ArgumentCaptor<String> idCatcher = ArgumentCaptor.forClass(String.class);
+        verify(proxier, times(2)).registerProxyDriver(eq(dummy), deviceCatcher.capture(), idCatcher.capture());
+        assertEquals("A", deviceCatcher.getValue().getName());
+        assertThat(new HashSet<String>(idCatcher.getAllValues())).isEqualTo(new HashSet<String>() {
+            {
+                add("id1");
+                add("id2");
+            }
+        });
+    }
+
+    @Test
+    public void AfterListingIfProxyingIsNotEnabledDoNothing() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T")));
+        Map<String, UpDriver> map = new HashMap<String, UpDriver>();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
+                ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        map.put("id1", dummy);
+        map.put("id2", dummy);
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", map));
+        when(proxier.doProxying()).thenReturn(false);
+        deviceManager.deviceEntered(enteree);
+        verify(proxier, never()).registerProxyDriver(any(UpDriver.class), any(UpDevice.class), any(String.class));
+    }
+
+    // public void deviceLeft(NetworkDevice device) {
+    @Test
+    public void removeTheDeviceFromDatabaseOnLeft() throws Exception {
+        NetworkDevice leavingCard = networkDevice("ADDR_UNKNOWN_A", "INEXISTENT");
+        UpDevice leavingGuy = upDevice("leavingMan", leavingCard);
+        when(connManager.getHost(eq(leavingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_A");
+        deviceManager.registerDevice(leavingGuy);
+
+        NetworkDevice stayingCard = networkDevice("ADDR_UNKNOWN_B", "INEXISTENT");
+        UpDevice stayingGuy = upDevice("stayingMan", stayingCard);
+        when(connManager.getHost(eq(stayingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_B");
+        deviceManager.registerDevice(stayingGuy);
+
+        assertEquals(3, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id4", driver, stayingGuy.getName()));
+        assertEquals(4, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingCard);
+        assertEquals(2, dao.list().size());
+        assertEquals(1, driverDao.list().size());
+    }
+
+    private UpDevice upDevice(String name, NetworkDevice networkCard) {
+        return new UpDevice(name).addNetworkInterface(networkCard.getNetworkDeviceName(),
+                networkCard.getNetworkDeviceType());
+    }
+
+    @Test
+    public void doNothingWhenLeftingANullDevice() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice oldGuy = upDevice("OldMan", leavingGuy);
+        when(connManager.getHost(eq(leavingGuy.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN");
+        deviceManager.registerDevice(oldGuy);
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
+        assertEquals(3, driverDao.list().size());
+
+        deviceManager.deviceLeft(null);
+        assertEquals(2, dao.list().size());
+        assertEquals(3, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingADeviceWithNullData() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice oldGuy = upDevice("OldMan", leavingGuy);
+        deviceManager.registerDevice(oldGuy);
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
+        assertEquals(3, driverDao.list().size());
+
+        deviceManager.deviceLeft(mock(NetworkDevice.class));
+        assertEquals(2, dao.list().size());
+        assertEquals(3, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingAnUnkownDevice() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        assertEquals(1, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
+        driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        assertEquals(2, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingGuy);
+        assertEquals(1, dao.list().size());
+        assertEquals(2, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingAnUnkownDevicexxxx() throws Exception {
+        NetworkDevice knownCard = networkDevice("ADDR_KNOWN", "THIS_ONE");
+        UpDevice knownGuy = upDevice("OldMan", knownCard);
+        deviceManager.registerDevice(knownGuy);
+
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "THIS_ONE");
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
+        driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        assertEquals(2, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingGuy);
+        assertEquals(2, dao.list().size());
+        assertEquals(2, driverDao.list().size());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowIfAddingNullDeviceListener() throws Exception {
+        deviceManager.addDeviceListener(null);
+    }
+
+    @Test
+    public void shouldNotThrowIfRemovingInvalidDeviceListener() throws Exception {
+        deviceManager.removeDeviceListener(null);
+        deviceManager.removeDeviceListener(mock(DeviceListener.class));
+    }
+
+    @Test
+    public void shouldCallDeviceEnteredOnListenersIfRegisteredSuccessfully() throws Exception {
+        DeviceListener listener = mock(DeviceListener.class);
+        deviceManager.addDeviceListener(listener);
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "INEXISTENT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy));
+        deviceManager.deviceEntered(enteree);
+        verify(listener, times(1)).deviceRegistered(newGuy);
+    }
+
+    @Test
+    public void shouldCallDeviceLeftOnListenersIfKnownDeviceLeft() throws Exception {
+        DeviceListener listener = mock(DeviceListener.class);
+        deviceManager.addDeviceListener(listener);
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "INEXISTENT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "INEXISTENT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy));
+        deviceManager.deviceEntered(enteree);
+        verify(listener, times(1)).deviceRegistered(newGuy);
+        deviceManager.deviceLeft(enteree);
+        verify(listener, times(1)).deviceUnregistered(newGuy);
+        verify(listener, times(1)).deviceRegistered(newGuy);
+    }
 }

--- a/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
+++ b/srcTest/org/unbiquitous/uos/core/deviceManager/DeviceManagerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,952 +54,1013 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class DeviceManagerTest {
 
-	private final JsonNodeFactory factory = JsonNodeFactory.instance;
-	private final ObjectMapper mapper = new ObjectMapper();
-
-	private DeviceDao dao;
-	private DeviceManager deviceManager;
-	private DriverManager driverManager;
-	private UpDevice currentDevice;
-	private DriverDao driverDao;
-	private ConnectionManagerControlCenter connManager;
-	private Gateway gateway;
-	private ConnectivityManager proxier;
-
-	@Before
-	@SuppressWarnings("rawtypes")
-	public void setUp() {
-		dao = new DeviceDao(null);
-		driverDao = new DriverDao(null);
-		connManager = mock(ConnectionManagerControlCenter.class);
-		when(connManager.getHost(anyString())).thenAnswer(new Answer() {
-			@Override
-			public String answer(InvocationOnMock invocation) throws Throwable {
-				return (String) invocation.getArguments()[0];
-			}
-		});
-		gateway = mock(Gateway.class);
-		proxier = mock(ConnectivityManager.class);
-		currentDevice = new UpDevice("myDevice").addNetworkInterface("127.0.0.1:80", "Ethernet:TCP");
-		driverManager = new DriverManager(currentDevice, driverDao, dao, new ReflectionServiceCaller(null));
-		deviceManager = new DeviceManager(currentDevice, dao, driverDao, connManager, proxier, gateway, driverManager);
-	}
-
-	@After
-	public void tearDown() {
-		((DeviceDao) dao).clear();
-		driverDao.clear();
-	}
-
-	// public DeviceManager( UpDevice currentDevice,
-	// ConnectionManagerControlCenter connectionManagerControlCenter,
-	// ConnectivityManager connectivityManager, ResourceBundle resourceBundle,
-	// Gateway gateway) {
-	@Test
-	public void shouldSaveCurrentDeviceOnStart() {
-		List<UpDevice> devices = dao.list(null, null);
-		assertNotNull(devices);
-		assertEquals(1, devices.size());
-		assertEquals(currentDevice, devices.get(0));
-	}
-
-	// public void registerDevice(UpDevice device){
-	@Test
-	public void shouldSaveWhenRegistering() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		List<UpDevice> devices = dao.list(null, null);
-		assertNotNull(devices);
-		assertEquals(2, devices.size());
-		assertTrue(devices.contains(toRegister));
-	}
-
-	// public UpDevice retrieveDevice(String deviceName){
-	@Test
-	public void shouldRetrieveRegisteredDevice() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNotNull(deviceManager.retrieveDevice("aDevice"));
-		assertEquals(toRegister, deviceManager.retrieveDevice("aDevice"));
-	}
-
-	@Test
-	public void shouldNotRetrieveAUnRegisteredDevice() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNull(deviceManager.retrieveDevice("NotDevice"));
-	}
-
-	// public UpDevice retrieveDevice(String networkAdrress, String
-	// networkType){
-	@Test
-	public void shouldRetrieveARegisteredDeviceByNetworkAddress() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNotNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
-		assertEquals(toRegister, deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
-	}
-
-	@Test
-	public void shouldNotRetrieveAUnRegisteredDeviceByNetworkAddress() {
-		UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(toRegister);
-		assertNull(deviceManager.retrieveDevice("127.0.0.3", "Ethernet:TCP"));
-		assertNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:UDP"));
-	}
-
-	@Test
-	public void listsAllRegisteredDevices() {
-		UpDevice first = new UpDevice("firstDevice").addNetworkInterface("127.0.0.1", "Ethernet:TCP");
-		deviceManager.registerDevice(first);
-		UpDevice second = new UpDevice("secondDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
-		deviceManager.registerDevice(second);
-		assertThat(deviceManager.listDevices()).containsOnly(currentDevice, first, second);
-	}
-
-	// TODO: two devices with the same name == trouble
-
-	@Test
-	public void shouldRetrieveMultipleInstancesByDriverName() throws DriverManagerException, DriverNotFoundException {
-		UpDriver driver = new UpDriver("d1");
-		UpDevice myPhone = new UpDevice("my.Phone");
-		deviceManager.registerDevice(myPhone);
-		driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
-		driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		driverManager.insert(new DriverModel("id3", new UpDriver("d3"), "my.tablet"));
-		List<DriverData> list = driverManager.listDrivers("d1", null);
-		assertNotNull(list);
-		assertEquals(2, list.size());
-		assertEquals("id1", list.get(0).getInstanceID());
-		assertEquals(myPhone, list.get(0).getDevice());
-		assertEquals("id2", list.get(1).getInstanceID());
-		assertEquals(currentDevice, list.get(1).getDevice());
-	}
-
-	@Test
-	public void shouldRetrieveMultipleInstancesByDeviceName() throws DriverManagerException, DriverNotFoundException {
-		UpDriver driver = new UpDriver("d1");
-		driver.addService("s1").addParameter("p1", ParameterType.MANDATORY);
-		UpDriver driverD3 = new UpDriver("d3");
-		driverD3.addEvent("e1");
-		UpDevice myPhone = new UpDevice("my.Phone");
-		deviceManager.registerDevice(myPhone);
-		driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
-		driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		driverManager.insert(new DriverModel("id3", driverD3, "my.Phone"));
-		List<DriverData> list = driverManager.listDrivers(null, "my.Phone");
-		assertNotNull(list);
-		assertEquals(2, list.size());
-		assertEquals("id1", list.get(0).getInstanceID());
-		assertEquals(myPhone, list.get(0).getDevice());
-		assertEquals(driver, list.get(0).getDriver());
-		assertEquals("id3", list.get(1).getInstanceID());
-		assertEquals(myPhone, list.get(1).getDevice());
-		assertEquals(driverD3, list.get(1).getDriver());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceIsAlreadyKnownShouldDoNothing() throws Exception {
-		deviceManager.registerDevice(new UpDevice("IShouldKnow").addNetworkInterface("ADDR_KNOWN", "UNEXISTANT"));
-		assertEquals(2, dao.list().size());
-		when(connManager.getHost(eq("ADDR_KNOWN"))).thenReturn("ADDR_KNOWN");
-		NetworkDevice enteree = mock(NetworkDevice.class);
-		when(enteree.getNetworkDeviceName()).thenReturn("ADDR_KNOWN");
-		when(enteree.getNetworkDeviceType()).thenReturn("UNEXISTANT");
-		deviceManager.deviceEntered(enteree);
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(2, dao.list().size());
-	}
-
-	// null device or device data (addr and type)
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceIsNullShouldDoNothing() throws Exception {
-		assertEquals(1, dao.list().size());
-		deviceManager.deviceEntered(null);
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void ifTheDeviceProvidesNoDatalShouldDoNothing() throws Exception {
-		assertEquals(1, dao.list().size());
-		deviceManager.deviceEntered(mock(NetworkDevice.class));
-		verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
-				any(String.class), any(String.class), any(Map.class));
-		assertEquals(1, dao.list().size());
-	}
-
-	// if doesn't knows the device, call 'handshake' on him passing
-	// currentDevice information
-	// Then register the device on the database
-
-	@Test
-	public void IfDontKnowTheDeviceCallAHandshakeWithIt() throws Exception {
-		when(gateway.callService((UpDevice) anyObject(), (Call) anyObject()))
-				.thenReturn(new Response().addParameter("device", mapper.writeValueAsString(new UpDevice("The Guy"))));
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		deviceManager.deviceEntered(enteree);
-		ArgumentCaptor<Call> scCacther = ArgumentCaptor.forClass(Call.class);
-		verify(gateway, times(2)).callService(any(UpDevice.class), scCacther.capture());
-		Call parameter = scCacther.getAllValues().get(0);
-		assertEquals("handshake", parameter.getService());
-		assertEquals("uos.DeviceDriver", parameter.getDriver());
-		assertNull(parameter.getInstanceId());
-		assertNull(parameter.getSecurityType());
-		assertEquals(currentDevice.toString(), parameter.getParameter("device"));
-	}
-
-	@Test
-	public void IfTheHandShakeWorksRegisterTheReturnedDevice() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheHandShakeHappensTwiceDoNothing() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheSecondHandShakeSucceedsRegisterDevice() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
-				.addNetworkInterface("127.255.255.666", "Ethernet:TFH");
-		deviceManager.deviceEntered(enteree);
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
-		deviceManager.deviceEntered(enteree);
-		assertEquals(2, dao.list().size());
-		assertEquals(newGuy, dao.find(newGuy.getName()));
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_NoResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(null);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_NoData() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(new Response());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_ErrorOnResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		Response error = new Response();
-		error.setError("Just Kidding");
-		when(gatewayHandshakeCall()).thenReturn(error);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	@Test
-	public void IfTheHandShakeDoesNotWorksNothingHappens_Exception() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenThrow(new RuntimeException());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(1, dao.list().size());
-	}
-
-	// if doesn't knows the device, call 'listDrivers'
-	// Then register the driver instances on the database
-
-	@Test
-	public void IfDontKnowTheDeviceCallListDriversOnIt() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		deviceManager.deviceEntered(enteree);
-		Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
-		verify(gateway, times(1)).callService(any(UpDevice.class), eq(listDrivers));
-	}
-
-	@Test
-	public void AfterListingTheDriverTheyMustBeRegistered() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
-				ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
-		deviceManager.deviceEntered(enteree);
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(2, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-		assertEquals("id2", newGuyDrivers.get(1).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToInterfaceValidationError() throws ServiceCallException, IOException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-
-		equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		UpService service = new UpService(Pointer.MOVE_EVENT);
-		service.addParameter(Pointer.AXIS_X, ParameterType.MANDATORY);
-		service.addParameter(Pointer.AXIS_Y, ParameterType.MANDATORY);
-		equivalentDriver.addEvent(service);
-
-		UpService register = new UpService("registerListener").addParameter("eventKey", ParameterType.MANDATORY);
-		equivalentDriver.addService(register);
-
-		UpService unregister = new UpService("unregisterListener").addParameter("eventKey", ParameterType.OPTIONAL);
-		equivalentDriver.addService(unregister);
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToNullEquivalentDriverResponse() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		when(gatewayTellEquivalentDriverCall()).thenReturn(null);
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToInterfaceNotProvided() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		ObjectNode driverList = factory.objectNode();
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		when(gatewayTellEquivalentDriverCall()).thenReturn(new Response().addParameter("interfaces", null));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToWrongJSONObject() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		when(gatewayListDriversCall())
-				.thenReturn(new Response().addParameter("driverList", new String("wrongJSONObject")));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToMissingServer() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverDueToEquivalentDriverInterfaceValidationError() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldNotRegisterADriverWithEquivalentDriverNotInformed() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-		equivalentDriver.addEquivalentDrivers("notInformedEquivalentDriver");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	public void shouldNotRegisterADriverWithTwoEquivalentDriversNotInformed() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver1");
-		dummy.addEquivalentDrivers("equivalentDriver2");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver1 = new UpDriver("equivalentDriver1");
-		equivalentDriver1.addService("s1");
-		equivalentDriver1.addEquivalentDrivers("notInformedEquivalentDriver1");
-		UpDriver equivalentDriver2 = new UpDriver("equivalentDriver2");
-		equivalentDriver2.addEquivalentDrivers("notInformedEquivalentDriver2");
-		equivalentDriver2.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver1));
-		jsonList.add(mapper.valueToTree(equivalentDriver2));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(0, newGuyDrivers.size());
-	}
-
-	@Test
-	public void shouldRegisterADriverWithUnknownEquivalentDriver() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-		assertEquals(1, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriver() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-
-		UpDriver dummy1 = new UpDriver("DummyDriver1");
-		dummy1.addService("s1");
-		dummy1.addEquivalentDrivers("equivalentDriver");
-
-		UpDriver dummy2 = new UpDriver("DummyDriver2");
-		dummy2.addService("s1");
-		dummy2.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("iddummy1", mapper.valueToTree(dummy1));
-		driverList.set("iddummy2", mapper.valueToTree(dummy2));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-
-		jsonList.add(mapper.valueToTree(equivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		assertEquals(2, newGuyDrivers.size());
-		assertEquals("iddummy1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
-		assertEquals("iddummy2", newGuyDrivers.get(1).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
-	}
-
-	@Test
-	public void shouldRegisterADriverWithTwoLevelsOfUnknownEquivalentDrivers() throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1");
-		dummy.addEquivalentDrivers("equivalentDriver");
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		UpDriver equivalentDriver = new UpDriver("equivalentDriver");
-		equivalentDriver.addService("s1");
-		equivalentDriver.addEquivalentDrivers("equivalentToTheEquivalentDriver");
-
-		UpDriver equivalentToTheEquivalentDriver = new UpDriver("equivalentToTheEquivalentDriver");
-		equivalentToTheEquivalentDriver.addService("s1");
-
-		ArrayNode equivalentDrivers = factory.arrayNode();
-		equivalentDrivers.add(mapper.valueToTree(equivalentDriver));
-		equivalentDrivers.add(mapper.valueToTree(equivalentToTheEquivalentDriver));
-
-		when(gatewayTellEquivalentDriverCall())
-				.thenReturn(new Response().addParameter("interfaces", equivalentDrivers.toString()));
-
-		deviceManager.deviceEntered(enteree);
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		// verify(gatewayTellEquivalentDriverCall(), times(2));
-		assertEquals(1, newGuyDrivers.size());
-		assertEquals("id1", newGuyDrivers.get(0).id());
-		assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
-	}
-
-	@Test
-	public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriverFromDifferentLevels()
-			throws ServiceCallException {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
-
-		when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
-
-		ObjectNode driverList = factory.objectNode();
-
-		UpDriver dummy1 = new UpDriver("D1");
-		dummy1.addService("s1");
-		dummy1.addEquivalentDrivers("D0");
-
-		UpDriver dummy2 = new UpDriver("D4");
-		dummy2.addService("s1");
-		dummy2.addEquivalentDrivers("D3");
-
-		driverList.set("iddummy1", mapper.valueToTree(dummy1));
-		driverList.set("iddummy2", mapper.valueToTree(dummy2));
-
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-
-		ArrayNode jsonList = factory.arrayNode();
-
-		UpDriver d0 = new UpDriver("D0");
-		d0.addService("s1");
-
-		UpDriver d2 = new UpDriver("D2");
-		d2.addService("s1");
-		d2.addEquivalentDrivers(d0.getName());
-
-		UpDriver d3 = new UpDriver("D3");
-		d3.addService("s1");
-		d3.addEquivalentDrivers(d2.getName());
-
-		jsonList.add(mapper.valueToTree(d3));
-		jsonList.add(mapper.valueToTree(d0));
-		jsonList.add(mapper.valueToTree(d2));
-
-		when(gatewayTellTwoEquivalentDrivers())
-				.thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
-
-		deviceManager.deviceEntered(enteree);
-
-		List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
-
-		// TODO: This
-		assertEquals(2, newGuyDrivers.size());
-		if (newGuyDrivers.get(0).id().equals("iddummy1")) {
-			assertEquals("iddummy1", newGuyDrivers.get(0).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
-			assertEquals("iddummy2", newGuyDrivers.get(1).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
-		} else {
-			assertEquals("iddummy2", newGuyDrivers.get(0).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy2));
-			assertEquals("iddummy1", newGuyDrivers.get(1).id());
-			assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy1));
-		}
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_NoResponse() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenReturn(null);
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_NoData() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenReturn(new Response());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	// FIXME: [B&M] Sempre passa! Como testar caso de erro?!
-	@Test
-	public void shouldNotHandshakeWithItsSelf() throws NetworkException, ServiceCallException {
-		NetworkDevice enteree = mock(NetworkDevice.class);
-
-		when(enteree.getNetworkDeviceName()).thenReturn("127.0.0.1:8080");
-		when(enteree.getNetworkDeviceType()).thenReturn("Ethernet:TCP");
-		when(connManager.getHost("127.0.0.1:8080")).thenReturn("127.0.0.1");
-		when(connManager.getHost("127.0.0.1:80")).thenReturn("127.0.0.1");
-		deviceManager.deviceEntered(enteree);
-		verify(gateway, never()).callService((UpDevice) any(), (Call) any());
-	}
-
-	@Test
-	public void IfTheListDriversDoesNotWorksNothingHappens_ThrowingException() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		when(gatewayListDriversCall()).thenThrow(new RuntimeException());
-		deviceManager.deviceEntered(enteree);
-		assertEquals(0, driverDao.list(null, "A").size());
-	}
-
-	private NetworkDevice networkDevice(String address, String type) {
-		NetworkDevice enteree = mock(NetworkDevice.class);
-		when(enteree.getNetworkDeviceName()).thenReturn(address);
-		when(enteree.getNetworkDeviceType()).thenReturn(type);
-		return enteree;
-	}
-
-	private Response gatewayHandshakeCall() throws ServiceCallException {
-		Call handshake = new Call("uos.DeviceDriver", "handshake", null);
-		handshake.addParameter("device", currentDevice.toString());
-		return gateway.callService(any(UpDevice.class), eq(handshake));
-	}
-
-	private Response gatewayListDriversCall() throws ServiceCallException {
-		Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
-		return gateway.callService(any(UpDevice.class), eq(listDrivers));
-	}
-
-	private Response gatewayTellEquivalentDriverCall() throws ServiceCallException {
-		Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
-		ArrayNode equivalents = factory.arrayNode();
-		equivalents.add(factory.textNode("equivalentDriver"));
-		tellEquivalentDriver.addParameter("driversName", equivalents.toString());
-		return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
-	}
-
-	private Response gatewayTellTwoEquivalentDrivers() throws ServiceCallException {
-		Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
-		ArrayNode equivalents = factory.arrayNode();
-		equivalents.add(factory.textNode("D0"));
-		equivalents.add(factory.textNode("D3"));
-		tellEquivalentDriver.addParameter("driversName", equivalents.toString());
-		return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
-	}
-
-	// TODO: What about proxying
-	@Test
-	public void AfterListingIfProxyingIsEnabledRegisterIt() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response()
-					.addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString())
-		);
-
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1")
-			.addParameter("s1p1", ParameterType.MANDATORY)
-			.addParameter("s1p2", ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-		when(proxier.doProxying()).thenReturn(true);
-		deviceManager.deviceEntered(enteree);
-		ArgumentCaptor<UpDevice> deviceCatcher = ArgumentCaptor.forClass(UpDevice.class);
-		ArgumentCaptor<String> idCatcher = ArgumentCaptor.forClass(String.class);
-		verify(proxier, times(2)).registerProxyDriver(eq(dummy), deviceCatcher.capture(), idCatcher.capture());
-		assertEquals("A", deviceCatcher.getValue().getName());
-		assertEquals("id1", idCatcher.getAllValues().get(0));
-		assertEquals("id2", idCatcher.getAllValues().get(1));
-	}
-
-	@Test
-	public void AfterListingIfProxyingIsNotEnabledDoNothing() throws Exception {
-		NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		when(gatewayHandshakeCall()).thenReturn(
-				new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
-		ObjectNode driverList = factory.objectNode();
-		UpDriver dummy = new UpDriver("DummyDriver");
-		dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
-				ParameterType.OPTIONAL);
-		dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
-
-		driverList.set("id1", mapper.valueToTree(dummy));
-		driverList.set("id2", mapper.valueToTree(dummy));
-		when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
-		when(proxier.doProxying()).thenReturn(false);
-		deviceManager.deviceEntered(enteree);
-		verify(proxier, never()).registerProxyDriver(any(UpDriver.class), any(UpDevice.class), any(String.class));
-	}
-
-	// public void deviceLeft(NetworkDevice device) {
-	@Test
-	public void removeTheDeviceFromDatabaseOnLeft() throws Exception {
-		NetworkDevice leavingCard = networkDevice("ADDR_UNKNOWN_A", "UNEXISTANT");
-		UpDevice leavingGuy = upDevice("leavingMan", leavingCard);
-		when(connManager.getHost(eq(leavingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_A");
-		deviceManager.registerDevice(leavingGuy);
-
-		NetworkDevice stayingCard = networkDevice("ADDR_UNKNOWN_B", "UNEXISTANT");
-		UpDevice stayingGuy = upDevice("stayingMan", stayingCard);
-		when(connManager.getHost(eq(stayingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_B");
-		deviceManager.registerDevice(stayingGuy);
-
-		assertEquals(3, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, leavingGuy.getName()));
-		driverDao.insert(new DriverModel("id4", driver, stayingGuy.getName()));
-		assertEquals(4, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingCard);
-		assertEquals(2, dao.list().size());
-		assertEquals(1, driverDao.list().size());
-	}
-
-	private UpDevice upDevice(String name, NetworkDevice networkCard) {
-		return new UpDevice(name).addNetworkInterface(networkCard.getNetworkDeviceName(),
-				networkCard.getNetworkDeviceType());
-	}
-
-	@Test
-	public void doNothingWhenLeftingANullDevice() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice oldGuy = upDevice("OldMan", leavingGuy);
-		when(connManager.getHost(eq(leavingGuy.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN");
-		deviceManager.registerDevice(oldGuy);
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
-		assertEquals(3, driverDao.list().size());
-
-		deviceManager.deviceLeft(null);
-		assertEquals(2, dao.list().size());
-		assertEquals(3, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingADeviceWithNullData() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		UpDevice oldGuy = upDevice("OldMan", leavingGuy);
-		deviceManager.registerDevice(oldGuy);
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
-		driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
-		assertEquals(3, driverDao.list().size());
-
-		deviceManager.deviceLeft(mock(NetworkDevice.class));
-		assertEquals(2, dao.list().size());
-		assertEquals(3, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingAnUnkownDevice() throws Exception {
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
-		assertEquals(1, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
-		driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		assertEquals(2, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingGuy);
-		assertEquals(1, dao.list().size());
-		assertEquals(2, driverDao.list().size());
-	}
-
-	@Test
-	public void doNothingWhenLeftingAnUnkownDevicexxxx() throws Exception {
-		NetworkDevice knownCard = networkDevice("ADDR_KNOWN", "THIS_ONE");
-		UpDevice knownGuy = upDevice("OldMan", knownCard);
-		deviceManager.registerDevice(knownGuy);
-
-		NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "THIS_ONE");
-		assertEquals(2, dao.list().size());
-		UpDriver driver = new UpDriver("DD");
-		driver.addService("s");
-		driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
-		driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
-		assertEquals(2, driverDao.list().size());
-
-		deviceManager.deviceLeft(leavingGuy);
-		assertEquals(2, dao.list().size());
-		assertEquals(2, driverDao.list().size());
-	}
+    private final JsonNodeFactory factory = JsonNodeFactory.instance;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private DeviceDao dao;
+    private DeviceManager deviceManager;
+    private DriverManager driverManager;
+    private UpDevice currentDevice;
+    private DriverDao driverDao;
+    private ConnectionManagerControlCenter connManager;
+    private Gateway gateway;
+    private ConnectivityManager proxier;
+
+    @Before
+    @SuppressWarnings("rawtypes")
+    public void setUp() {
+        dao = new DeviceDao(null);
+        driverDao = new DriverDao(null);
+        connManager = mock(ConnectionManagerControlCenter.class);
+        when(connManager.getHost(anyString())).thenAnswer(new Answer() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return (String) invocation.getArguments()[0];
+            }
+        });
+        gateway = mock(Gateway.class);
+        proxier = mock(ConnectivityManager.class);
+        currentDevice = new UpDevice("myDevice").addNetworkInterface("127.0.0.1:80", "Ethernet:TCP");
+        driverManager = new DriverManager(currentDevice, driverDao, dao, new ReflectionServiceCaller(null));
+        deviceManager = new DeviceManager(currentDevice, dao, driverDao, connManager, proxier, gateway, driverManager);
+    }
+
+    @After
+    public void tearDown() {
+        ((DeviceDao) dao).clear();
+        driverDao.clear();
+    }
+
+    // public DeviceManager( UpDevice currentDevice,
+    // ConnectionManagerControlCenter connectionManagerControlCenter,
+    // ConnectivityManager connectivityManager, ResourceBundle resourceBundle,
+    // Gateway gateway) {
+    @Test
+    public void shouldSaveCurrentDeviceOnStart() {
+        List<UpDevice> devices = dao.list(null, null);
+        assertNotNull(devices);
+        assertEquals(1, devices.size());
+        assertEquals(currentDevice, devices.get(0));
+    }
+
+    // public void registerDevice(UpDevice device){
+    @Test
+    public void shouldSaveWhenRegistering() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        List<UpDevice> devices = dao.list(null, null);
+        assertNotNull(devices);
+        assertEquals(2, devices.size());
+        assertTrue(devices.contains(toRegister));
+    }
+
+    // public UpDevice retrieveDevice(String deviceName){
+    @Test
+    public void shouldRetrieveRegisteredDevice() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNotNull(deviceManager.retrieveDevice("aDevice"));
+        assertEquals(toRegister, deviceManager.retrieveDevice("aDevice"));
+    }
+
+    @Test
+    public void shouldNotRetrieveAUnRegisteredDevice() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNull(deviceManager.retrieveDevice("NotDevice"));
+    }
+
+    // public UpDevice retrieveDevice(String networkAdrress, String
+    // networkType){
+    @Test
+    public void shouldRetrieveARegisteredDeviceByNetworkAddress() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNotNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
+        assertEquals(toRegister, deviceManager.retrieveDevice("127.0.0.2", "Ethernet:TCP"));
+    }
+
+    @Test
+    public void shouldNotRetrieveAUnRegisteredDeviceByNetworkAddress() {
+        UpDevice toRegister = new UpDevice("aDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(toRegister);
+        assertNull(deviceManager.retrieveDevice("127.0.0.3", "Ethernet:TCP"));
+        assertNull(deviceManager.retrieveDevice("127.0.0.2", "Ethernet:UDP"));
+    }
+
+    @Test
+    public void listsAllRegisteredDevices() {
+        UpDevice first = new UpDevice("firstDevice").addNetworkInterface("127.0.0.1", "Ethernet:TCP");
+        deviceManager.registerDevice(first);
+        UpDevice second = new UpDevice("secondDevice").addNetworkInterface("127.0.0.2", "Ethernet:TCP");
+        deviceManager.registerDevice(second);
+        assertThat(deviceManager.listDevices()).containsOnly(currentDevice, first, second);
+    }
+
+    // TODO: two devices with the same name == trouble
+
+    @Test
+    public void shouldRetrieveMultipleInstancesByDriverName() throws DriverManagerException, DriverNotFoundException {
+        UpDriver driver = new UpDriver("d1");
+        UpDevice myPhone = new UpDevice("my.Phone");
+        deviceManager.registerDevice(myPhone);
+        driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
+        driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        driverManager.insert(new DriverModel("id3", new UpDriver("d3"), "my.tablet"));
+        List<DriverData> list = driverManager.listDrivers("d1", null);
+        assertNotNull(list);
+        assertEquals(2, list.size());
+        assertEquals("id1", list.get(0).getInstanceID());
+        assertEquals(myPhone, list.get(0).getDevice());
+        assertEquals("id2", list.get(1).getInstanceID());
+        assertEquals(currentDevice, list.get(1).getDevice());
+    }
+
+    @Test
+    public void shouldRetrieveMultipleInstancesByDeviceName() throws DriverManagerException, DriverNotFoundException {
+        UpDriver driver = new UpDriver("d1");
+        driver.addService("s1").addParameter("p1", ParameterType.MANDATORY);
+        UpDriver driverD3 = new UpDriver("d3");
+        driverD3.addEvent("e1");
+        UpDevice myPhone = new UpDevice("my.Phone");
+        deviceManager.registerDevice(myPhone);
+        driverManager.insert(new DriverModel("id1", driver, "my.Phone"));
+        driverManager.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        driverManager.insert(new DriverModel("id3", driverD3, "my.Phone"));
+        List<DriverData> list = driverManager.listDrivers(null, "my.Phone");
+        assertNotNull(list);
+        assertEquals(2, list.size());
+        assertEquals("id1", list.get(0).getInstanceID());
+        assertEquals(myPhone, list.get(0).getDevice());
+        assertEquals(driver, list.get(0).getDriver());
+        assertEquals("id3", list.get(1).getInstanceID());
+        assertEquals(myPhone, list.get(1).getDevice());
+        assertEquals(driverD3, list.get(1).getDriver());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceIsAlreadyKnownShouldDoNothing() throws Exception {
+        deviceManager.registerDevice(new UpDevice("IShouldKnow").addNetworkInterface("ADDR_KNOWN", "UNEXISTANT"));
+        assertEquals(2, dao.list().size());
+        when(connManager.getHost(eq("ADDR_KNOWN"))).thenReturn("ADDR_KNOWN");
+        NetworkDevice enteree = mock(NetworkDevice.class);
+        when(enteree.getNetworkDeviceName()).thenReturn("ADDR_KNOWN");
+        when(enteree.getNetworkDeviceType()).thenReturn("UNEXISTANT");
+        deviceManager.deviceEntered(enteree);
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(2, dao.list().size());
+    }
+
+    // null device or device data (addr and type)
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceIsNullShouldDoNothing() throws Exception {
+        assertEquals(1, dao.list().size());
+        deviceManager.deviceEntered(null);
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ifTheDeviceProvidesNoDatalShouldDoNothing() throws Exception {
+        assertEquals(1, dao.list().size());
+        deviceManager.deviceEntered(mock(NetworkDevice.class));
+        verify(gateway, never()).callService(any(UpDevice.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        assertEquals(1, dao.list().size());
+    }
+
+    // if doesn't knows the device, call 'handshake' on him passing
+    // currentDevice information
+    // Then register the device on the database
+
+    @Test
+    public void IfDontKnowTheDeviceCallAHandshakeWithIt() throws Exception {
+        when(gateway.callService((UpDevice) anyObject(), (Call) anyObject()))
+                .thenReturn(new Response().addParameter("device", mapper.writeValueAsString(new UpDevice("The Guy"))));
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        deviceManager.deviceEntered(enteree);
+        ArgumentCaptor<Call> scCacther = ArgumentCaptor.forClass(Call.class);
+        verify(gateway, times(2)).callService(any(UpDevice.class), scCacther.capture());
+        Call parameter = scCacther.getAllValues().get(0);
+        assertEquals("handshake", parameter.getService());
+        assertEquals("uos.DeviceDriver", parameter.getDriver());
+        assertNull(parameter.getInstanceId());
+        assertNull(parameter.getSecurityType());
+        assertEquals(currentDevice.toString(), parameter.getParameter("device"));
+    }
+
+    @Test
+    public void IfTheHandShakeWorksRegisterTheReturnedDevice() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheHandShakeHappensTwiceDoNothing() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheSecondHandShakeSucceedsRegisterDevice() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        deviceManager.deviceEntered(enteree);
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(2, dao.list().size());
+        assertEquals(newGuy, dao.find(newGuy.getName()));
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_NoResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(null);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_NoData() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(new Response());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_ErrorOnResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        Response error = new Response();
+        error.setError("Just Kidding");
+        when(gatewayHandshakeCall()).thenReturn(error);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    @Test
+    public void IfTheHandShakeDoesNotWorksNothingHappens_Exception() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenThrow(new RuntimeException());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, dao.list().size());
+    }
+
+    // if doesn't knows the device, call 'listDrivers'
+    // Then register the driver instances on the database
+
+    @Test
+    public void IfDontKnowTheDeviceCallListDriversOnIt() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        deviceManager.deviceEntered(enteree);
+        Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
+        verify(gateway, times(1)).callService(any(UpDevice.class), eq(listDrivers));
+    }
+
+    @Test
+    public void AfterListingTheDriverTheyMustBeRegistered() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
+                ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+        driverList.set("id2", mapper.valueToTree(dummy));
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
+        deviceManager.deviceEntered(enteree);
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(2, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
+        assertEquals("id2", newGuyDrivers.get(1).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy));
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToInterfaceValidationError() throws ServiceCallException, IOException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        ObjectNode driverList = factory.objectNode();
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+
+        equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        UpService service = new UpService(Pointer.MOVE_EVENT);
+        service.addParameter(Pointer.AXIS_X, ParameterType.MANDATORY);
+        service.addParameter(Pointer.AXIS_Y, ParameterType.MANDATORY);
+        equivalentDriver.addEvent(service);
+
+        UpService register = new UpService("registerListener").addParameter("eventKey", ParameterType.MANDATORY);
+        equivalentDriver.addService(register);
+
+        UpService unregister = new UpService("unregisterListener").addParameter("eventKey", ParameterType.OPTIONAL);
+        equivalentDriver.addService(unregister);
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToNullEquivalentDriverResponse() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        ObjectNode driverList = factory.objectNode();
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        when(gatewayTellEquivalentDriverCall()).thenReturn(null);
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToInterfaceNotProvided() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        ObjectNode driverList = factory.objectNode();
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        when(gatewayTellEquivalentDriverCall()).thenReturn(new Response().addParameter("interfaces", null));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToWrongJSONObject() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        when(gatewayListDriversCall())
+                .thenReturn(new Response().addParameter("driverList", new String("wrongJSONObject")));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToMissingServer() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers(Pointer.DRIVER_NAME);
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverDueToEquivalentDriverInterfaceValidationError() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addEquivalentDrivers(Pointer.DRIVER_NAME);
+        equivalentDriver.addService("s1");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldNotRegisterADriverWithEquivalentDriverNotInformed() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+        equivalentDriver.addEquivalentDrivers("notInformedEquivalentDriver");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    public void shouldNotRegisterADriverWithTwoEquivalentDriversNotInformed() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver1");
+        dummy.addEquivalentDrivers("equivalentDriver2");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver1 = new UpDriver("equivalentDriver1");
+        equivalentDriver1.addService("s1");
+        equivalentDriver1.addEquivalentDrivers("notInformedEquivalentDriver1");
+        UpDriver equivalentDriver2 = new UpDriver("equivalentDriver2");
+        equivalentDriver2.addEquivalentDrivers("notInformedEquivalentDriver2");
+        equivalentDriver2.addService("s1");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver1));
+        jsonList.add(mapper.valueToTree(equivalentDriver2));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(0, newGuyDrivers.size());
+    }
+
+    @Test
+    public void shouldRegisterADriverWithUnknownEquivalentDriver() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+        assertEquals(1, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
+    }
+
+    @Test
+    public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriver() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+
+        UpDriver dummy1 = new UpDriver("DummyDriver1");
+        dummy1.addService("s1");
+        dummy1.addEquivalentDrivers("equivalentDriver");
+
+        UpDriver dummy2 = new UpDriver("DummyDriver2");
+        dummy2.addService("s1");
+        dummy2.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("iddummy1", mapper.valueToTree(dummy1));
+        driverList.set("iddummy2", mapper.valueToTree(dummy2));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+
+        jsonList.add(mapper.valueToTree(equivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        assertEquals(2, newGuyDrivers.size());
+        assertEquals("iddummy1", newGuyDrivers.get(0).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
+        assertEquals("iddummy2", newGuyDrivers.get(1).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
+    }
+
+    @Test
+    public void shouldRegisterADriverWithTwoLevelsOfUnknownEquivalentDrivers() throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1");
+        dummy.addEquivalentDrivers("equivalentDriver");
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        UpDriver equivalentDriver = new UpDriver("equivalentDriver");
+        equivalentDriver.addService("s1");
+        equivalentDriver.addEquivalentDrivers("equivalentToTheEquivalentDriver");
+
+        UpDriver equivalentToTheEquivalentDriver = new UpDriver("equivalentToTheEquivalentDriver");
+        equivalentToTheEquivalentDriver.addService("s1");
+
+        ArrayNode equivalentDrivers = factory.arrayNode();
+        equivalentDrivers.add(mapper.valueToTree(equivalentDriver));
+        equivalentDrivers.add(mapper.valueToTree(equivalentToTheEquivalentDriver));
+
+        when(gatewayTellEquivalentDriverCall())
+                .thenReturn(new Response().addParameter("interfaces", equivalentDrivers.toString()));
+
+        deviceManager.deviceEntered(enteree);
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        // verify(gatewayTellEquivalentDriverCall(), times(2));
+        assertEquals(1, newGuyDrivers.size());
+        assertEquals("id1", newGuyDrivers.get(0).id());
+        assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy));
+    }
+
+    @Test
+    public void shouldRegisterTwoDriversWithTheSameUnknownEquivalentDriverFromDifferentLevels()
+            throws ServiceCallException {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice device = new UpDevice("A").addNetworkInterface("A", "T");
+
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", device.toString()));
+
+        ObjectNode driverList = factory.objectNode();
+
+        UpDriver dummy1 = new UpDriver("D1");
+        dummy1.addService("s1");
+        dummy1.addEquivalentDrivers("D0");
+
+        UpDriver dummy2 = new UpDriver("D4");
+        dummy2.addService("s1");
+        dummy2.addEquivalentDrivers("D3");
+
+        driverList.set("iddummy1", mapper.valueToTree(dummy1));
+        driverList.set("iddummy2", mapper.valueToTree(dummy2));
+
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+
+        ArrayNode jsonList = factory.arrayNode();
+
+        UpDriver d0 = new UpDriver("D0");
+        d0.addService("s1");
+
+        UpDriver d2 = new UpDriver("D2");
+        d2.addService("s1");
+        d2.addEquivalentDrivers(d0.getName());
+
+        UpDriver d3 = new UpDriver("D3");
+        d3.addService("s1");
+        d3.addEquivalentDrivers(d2.getName());
+
+        jsonList.add(mapper.valueToTree(d3));
+        jsonList.add(mapper.valueToTree(d0));
+        jsonList.add(mapper.valueToTree(d2));
+
+        when(gatewayTellTwoEquivalentDrivers())
+                .thenReturn(new Response().addParameter("interfaces", jsonList.toString()));
+
+        deviceManager.deviceEntered(enteree);
+
+        List<DriverModel> newGuyDrivers = driverDao.list(null, "A");
+
+        // TODO: This
+        assertEquals(2, newGuyDrivers.size());
+        if (newGuyDrivers.get(0).id().equals("iddummy1")) {
+            assertEquals("iddummy1", newGuyDrivers.get(0).id());
+            assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy1));
+            assertEquals("iddummy2", newGuyDrivers.get(1).id());
+            assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy2));
+        } else {
+            assertEquals("iddummy2", newGuyDrivers.get(0).id());
+            assertThat(mapper.valueToTree(newGuyDrivers.get(0).driver())).isEqualTo(mapper.valueToTree(dummy2));
+            assertEquals("iddummy1", newGuyDrivers.get(1).id());
+            assertThat(mapper.valueToTree(newGuyDrivers.get(1).driver())).isEqualTo(mapper.valueToTree(dummy1));
+        }
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_NoResponse() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        when(gatewayListDriversCall()).thenReturn(null);
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_NoData() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        when(gatewayListDriversCall()).thenReturn(new Response());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    // FIXME: [B&M] Sempre passa! Como testar caso de erro?!
+    @Test
+    public void shouldNotHandshakeWithItsSelf() throws NetworkException, ServiceCallException {
+        NetworkDevice enteree = mock(NetworkDevice.class);
+
+        when(enteree.getNetworkDeviceName()).thenReturn("127.0.0.1:8080");
+        when(enteree.getNetworkDeviceType()).thenReturn("Ethernet:TCP");
+        when(connManager.getHost("127.0.0.1:8080")).thenReturn("127.0.0.1");
+        when(connManager.getHost("127.0.0.1:80")).thenReturn("127.0.0.1");
+        deviceManager.deviceEntered(enteree);
+        verify(gateway, never()).callService((UpDevice) any(), (Call) any());
+    }
+
+    @Test
+    public void IfTheListDriversDoesNotWorksNothingHappens_ThrowingException() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        when(gatewayListDriversCall()).thenThrow(new RuntimeException());
+        deviceManager.deviceEntered(enteree);
+        assertEquals(0, driverDao.list(null, "A").size());
+    }
+
+    private NetworkDevice networkDevice(String address, String type) {
+        NetworkDevice enteree = mock(NetworkDevice.class);
+        when(enteree.getNetworkDeviceName()).thenReturn(address);
+        when(enteree.getNetworkDeviceType()).thenReturn(type);
+        return enteree;
+    }
+
+    private Response gatewayHandshakeCall() throws ServiceCallException {
+        Call handshake = new Call("uos.DeviceDriver", "handshake", null);
+        handshake.addParameter("device", currentDevice.toString());
+        return gateway.callService(any(UpDevice.class), eq(handshake));
+    }
+
+    private Response gatewayListDriversCall() throws ServiceCallException {
+        Call listDrivers = new Call("uos.DeviceDriver", "listDrivers", null);
+        return gateway.callService(any(UpDevice.class), eq(listDrivers));
+    }
+
+    private Response gatewayTellEquivalentDriverCall() throws ServiceCallException {
+        Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
+        ArrayNode equivalents = factory.arrayNode();
+        equivalents.add(factory.textNode("equivalentDriver"));
+        tellEquivalentDriver.addParameter("driversName", equivalents.toString());
+        return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
+    }
+
+    private Response gatewayTellTwoEquivalentDrivers() throws ServiceCallException {
+        Call tellEquivalentDriver = new Call("uos.DeviceDriver", "tellEquivalentDrivers", null);
+        ArrayNode equivalents = factory.arrayNode();
+        equivalents.add(factory.textNode("D0"));
+        equivalents.add(factory.textNode("D3"));
+        tellEquivalentDriver.addParameter("driversName", equivalents.toString());
+        return gateway.callService(any(UpDevice.class), eq(tellEquivalentDriver));
+    }
+
+    // TODO: What about proxying
+    @Test
+    public void AfterListingIfProxyingIsEnabledRegisterIt() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response()
+                        .addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString())
+        );
+
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1")
+                .addParameter("s1p1", ParameterType.MANDATORY)
+                .addParameter("s1p2", ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+        driverList.set("id2", mapper.valueToTree(dummy));
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+        when(proxier.doProxying()).thenReturn(true);
+        deviceManager.deviceEntered(enteree);
+        ArgumentCaptor<UpDevice> deviceCatcher = ArgumentCaptor.forClass(UpDevice.class);
+        ArgumentCaptor<String> idCatcher = ArgumentCaptor.forClass(String.class);
+        verify(proxier, times(2)).registerProxyDriver(eq(dummy), deviceCatcher.capture(), idCatcher.capture());
+        assertEquals("A", deviceCatcher.getValue().getName());
+        assertEquals("id1", idCatcher.getAllValues().get(0));
+        assertEquals("id2", idCatcher.getAllValues().get(1));
+    }
+
+    @Test
+    public void AfterListingIfProxyingIsNotEnabledDoNothing() throws Exception {
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        when(gatewayHandshakeCall()).thenReturn(
+                new Response().addParameter("device", new UpDevice("A").addNetworkInterface("A", "T").toString()));
+        ObjectNode driverList = factory.objectNode();
+        UpDriver dummy = new UpDriver("DummyDriver");
+        dummy.addService("s1").addParameter("s1p1", ParameterType.MANDATORY).addParameter("s1p2",
+                ParameterType.OPTIONAL);
+        dummy.addService("s2").addParameter("s2p1", ParameterType.MANDATORY);
+
+        driverList.set("id1", mapper.valueToTree(dummy));
+        driverList.set("id2", mapper.valueToTree(dummy));
+        when(gatewayListDriversCall()).thenReturn(new Response().addParameter("driverList", driverList.toString()));
+        when(proxier.doProxying()).thenReturn(false);
+        deviceManager.deviceEntered(enteree);
+        verify(proxier, never()).registerProxyDriver(any(UpDriver.class), any(UpDevice.class), any(String.class));
+    }
+
+    // public void deviceLeft(NetworkDevice device) {
+    @Test
+    public void removeTheDeviceFromDatabaseOnLeft() throws Exception {
+        NetworkDevice leavingCard = networkDevice("ADDR_UNKNOWN_A", "UNEXISTANT");
+        UpDevice leavingGuy = upDevice("leavingMan", leavingCard);
+        when(connManager.getHost(eq(leavingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_A");
+        deviceManager.registerDevice(leavingGuy);
+
+        NetworkDevice stayingCard = networkDevice("ADDR_UNKNOWN_B", "UNEXISTANT");
+        UpDevice stayingGuy = upDevice("stayingMan", stayingCard);
+        when(connManager.getHost(eq(stayingCard.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN_B");
+        deviceManager.registerDevice(stayingGuy);
+
+        assertEquals(3, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, leavingGuy.getName()));
+        driverDao.insert(new DriverModel("id4", driver, stayingGuy.getName()));
+        assertEquals(4, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingCard);
+        assertEquals(2, dao.list().size());
+        assertEquals(1, driverDao.list().size());
+    }
+
+    private UpDevice upDevice(String name, NetworkDevice networkCard) {
+        return new UpDevice(name).addNetworkInterface(networkCard.getNetworkDeviceName(),
+                networkCard.getNetworkDeviceType());
+    }
+
+    @Test
+    public void doNothingWhenLeftingANullDevice() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice oldGuy = upDevice("OldMan", leavingGuy);
+        when(connManager.getHost(eq(leavingGuy.getNetworkDeviceName()))).thenReturn("ADDR_UNKNOWN");
+        deviceManager.registerDevice(oldGuy);
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
+        assertEquals(3, driverDao.list().size());
+
+        deviceManager.deviceLeft(null);
+        assertEquals(2, dao.list().size());
+        assertEquals(3, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingADeviceWithNullData() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice oldGuy = upDevice("OldMan", leavingGuy);
+        deviceManager.registerDevice(oldGuy);
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id2", driver, oldGuy.getName()));
+        driverDao.insert(new DriverModel("id3", driver, oldGuy.getName()));
+        assertEquals(3, driverDao.list().size());
+
+        deviceManager.deviceLeft(mock(NetworkDevice.class));
+        assertEquals(2, dao.list().size());
+        assertEquals(3, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingAnUnkownDevice() throws Exception {
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        assertEquals(1, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
+        driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        assertEquals(2, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingGuy);
+        assertEquals(1, dao.list().size());
+        assertEquals(2, driverDao.list().size());
+    }
+
+    @Test
+    public void doNothingWhenLeftingAnUnkownDevicexxxx() throws Exception {
+        NetworkDevice knownCard = networkDevice("ADDR_KNOWN", "THIS_ONE");
+        UpDevice knownGuy = upDevice("OldMan", knownCard);
+        deviceManager.registerDevice(knownGuy);
+
+        NetworkDevice leavingGuy = networkDevice("ADDR_UNKNOWN", "THIS_ONE");
+        assertEquals(2, dao.list().size());
+        UpDriver driver = new UpDriver("DD");
+        driver.addService("s");
+        driverDao.insert(new DriverModel("id1", driver, currentDevice.getName()));
+        driverDao.insert(new DriverModel("id2", driver, currentDevice.getName()));
+        assertEquals(2, driverDao.list().size());
+
+        deviceManager.deviceLeft(leavingGuy);
+        assertEquals(2, dao.list().size());
+        assertEquals(2, driverDao.list().size());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowIfAddingNullDeviceListener() throws Exception {
+        deviceManager.addDeviceListener(null);
+    }
+
+    @Test
+    public void shouldNotThrowIfRemovingInvalidDeviceListener() throws Exception {
+        deviceManager.removeDeviceListener(null);
+        deviceManager.removeDeviceListener(new DeviceListenerSwitch());
+    }
+
+    @Test
+    public void shouldCallDeviceEnteredOnListenersIfRegisteredSuccessfully() throws Exception {
+        DeviceListenerSwitch listener = new DeviceListenerSwitch();
+        deviceManager.addDeviceListener(listener);
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, listener.getEnteredCount(newGuy));
+    }
+
+    @Test
+    public void shouldCallDeviceLeftOnListenersIfKnownDeviceLeft() throws Exception {
+        DeviceListenerSwitch listener = new DeviceListenerSwitch();
+        deviceManager.addDeviceListener(listener);
+        NetworkDevice enteree = networkDevice("ADDR_UNKNOWN", "UNEXISTANT");
+        UpDevice newGuy = new UpDevice("TheNewGuy").addNetworkInterface("ADDR_UNKNOWN", "UNEXISTANT")
+                .addNetworkInterface("127.255.255.666", "Ethernet:TFH");
+        when(gatewayHandshakeCall()).thenReturn(new Response().addParameter("device", newGuy.toString()));
+        deviceManager.deviceEntered(enteree);
+        assertEquals(1, listener.getEnteredCount(newGuy));
+        deviceManager.deviceLeft(enteree);
+        assertEquals(1, listener.getEnteredCount(newGuy));
+        assertEquals(1, listener.getLeftCount(newGuy));
+    }
+
+    private static class DeviceListenerSwitch implements DeviceListener {
+        private Map<UpDevice, Integer> enteredDevices = new HashMap<UpDevice, Integer>();
+        private Map<UpDevice, Integer> leftDevices = new HashMap<UpDevice, Integer>();
+
+        @Override
+        public void deviceRegistered(UpDevice device) {
+            enteredDevices.put(device, getEnteredCount(device) + 1);
+        }
+
+        @Override
+        public void deviceUnregistered(UpDevice device) {
+            leftDevices.put(device, getLeftCount(device) + 1);
+        }
+
+        public int getEnteredCount(UpDevice device) {
+            return enteredDevices.containsKey(device) ? enteredDevices.get(device) : 0;
+        }
+
+        public int getLeftCount(UpDevice device) {
+            return leftDevices.containsKey(device) ? leftDevices.get(device) : 0;
+        }
+    }
 }


### PR DESCRIPTION
Included capacity to notify interested listeners when devices enter and leave smartspace. Also, for DeviceManager and DeviceDriver, a more (jackson/json) transparent implementation, handling "objects as JSON strings" and "objects as JSON objects" cases elegantly. This modification also prevents data from traveling in the "JSON objects as strings" formats and serialiazes/deserializes all basic objects to/from JSON directly. Removed events "deviceEntered" and "deviceLeft" from DeviceDriver. Now, DeviceManager can make those notifications in a more reliable way. I was young and naive when I put those on DeviceDriver :-)
